### PR TITLE
Adapt to use docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.1.0] - 2021-10-28
+### Changed
+- `operator-rs` `0.3.0` → `0.4.0` ([#25]).
+- Adapted pod image and container command to docker image ([#25]).
+- Adapted documentation to represent new workflow with docker images ([#25]).
 
+[#25]: https://github.com/stackabletech/hbase-operator/pull/25
+
+## [0.1.0] - 2021-10-28
 
 ### Changed
 - `operator-rs`: `0.3.0` ([#18])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - `operator-rs` `0.3.0` → `0.4.0` ([#25]).
+- `stackable-hdfs-crd` `0.1.0` → `0.2.0` ([#25]).
+- `stackable-zookeeper-crd` `0.4.1` → `0.5.0` ([#25]).
 - Adapted pod image and container command to docker image ([#25]).
 - Adapted documentation to represent new workflow with docker images ([#25]).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.63.1"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c19c08adecde7d68052bfccf9f8ae663f680380e297f20249cef7943df66f54"
+checksum = "75e877325e5540a3041b519bd7ee27a858691f9f816cf533d652cbb33cbfea45"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -783,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.63.1"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7ca26f7b912055aec302c376de4f3e1c749d121fbed91088203848e3dbd978"
+checksum = "bb8e1a36f17c63e263ba0ffa2c0658de315c75decad983d83aaeafeda578cc78"
 dependencies = [
  "base64",
  "bytes",
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.63.1"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56229a53d7ce86e3e31c4aaf18a957b6f68305126ebfb12523312b2c8a43f19c"
+checksum = "a91e572d244436fbc0d0b5a4829d96b9d623e08eb6b5d1e80418c1fab10b162a"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -839,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.63.1"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a9c6f93a170382c384eddf05ba165a96b38ecc63db8814d750db2ee349bd89"
+checksum = "2034f57f3db36978ef366f45f1e263e623d9a6a8fcc6a6b1ef8879a213e1d2c4"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -852,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.63.1"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a168bfeebab8913a0fca198c1f30d8d8c5f04d3eee1645aa5619a27a0a656c14"
+checksum = "6018cf8410f9d460be3a3ac35deef63b71c860c368016d7bf6871994343728b4"
 dependencies = [
  "dashmap",
  "derivative",
@@ -880,9 +880,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "libgit2-sys"
@@ -1030,9 +1030,9 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "openssl"
-version = "0.10.36"
+version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1050,9 +1050,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.67"
+version = "0.9.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
+checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
 dependencies = [
  "autocfg",
  "cc",
@@ -1198,8 +1198,8 @@ dependencies = [
 
 [[package]]
 name = "product-config"
-version = "0.2.0-nightly"
-source = "git+https://github.com/stackabletech/product-config.git?branch=main#97734dfa78c5e96922b2fc99bbd0cf2a1b7ac89d"
+version = "0.2.0"
+source = "git+https://github.com/stackabletech/product-config.git?tag=0.2.0#e32e33d9094e09b1af29045e05a4ab17c511cedb"
 dependencies = [
  "java-properties",
  "regex",
@@ -1511,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1656,8 +1656,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-hdfs-crd"
-version = "0.1.0"
-source = "git+https://github.com/stackabletech/hdfs-operator.git?tag=0.1.0#be39c1a4094fddf535aaa3969402f8363b5adb40"
+version = "0.2.0-nightly"
+source = "git+https://github.com/stackabletech/hdfs-operator.git?branch=adapt_to_use_docker_image#86de4767525ab4011ac5002960bf434e6196b603"
 dependencies = [
  "duplicate",
  "semver",
@@ -1672,8 +1672,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.3.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.3.0#a0a1d10260f7921d436a0cd7ba6ce957368e42fb"
+version = "0.4.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.4.0#50c3ee9564b1d3eb9d6e43c5e87c2102afbacc27"
 dependencies = [
  "async-trait",
  "backoff",
@@ -1705,8 +1705,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-zookeeper-crd"
-version = "0.4.1"
-source = "git+https://github.com/stackabletech/zookeeper-operator.git?tag=0.4.1#a95a0cb793d07ea9a7a8fcfc6cf4c4ea16452284"
+version = "0.5.0-nightly"
+source = "git+https://github.com/stackabletech/zookeeper-operator.git?branch=adapt_to_use_docker_image#6ecf8a00852fb4f88f94c4fa52324f1c7ae233a8"
 dependencies = [
  "duplicate",
  "semver",
@@ -1867,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1899,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 dependencies = [
  "jobserver",
 ]
@@ -1656,8 +1656,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-hdfs-crd"
-version = "0.2.0-nightly"
-source = "git+https://github.com/stackabletech/hdfs-operator.git?branch=adapt_to_use_docker_image#86de4767525ab4011ac5002960bf434e6196b603"
+version = "0.2.0"
+source = "git+https://github.com/stackabletech/hdfs-operator.git?tag=0.2.0#b0215525713a3ef2c932cbb21258f011336627bd"
 dependencies = [
  "duplicate",
  "semver",
@@ -1705,8 +1705,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-zookeeper-crd"
-version = "0.5.0-nightly"
-source = "git+https://github.com/stackabletech/zookeeper-operator.git?branch=adapt_to_use_docker_image#6ecf8a00852fb4f88f94c4fa52324f1c7ae233a8"
+version = "0.5.0"
+source = "git+https://github.com/stackabletech/zookeeper-operator.git?tag=0.5.0#45ebcca59ee128af363d0266b83cd3c05a6659a9"
 dependencies = [
  "duplicate",
  "semver",
@@ -1825,9 +1825,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/README.adoc
+++ b/README.adoc
@@ -2,6 +2,4 @@
 
 This is a Kubernetes Operator to manage Apache HBase ensembles.
 
-It is written by https://www.stackable.de[Stackable] in Rust, and it is supposed to be used with the https://github.com/stackabletech/agent[Stackable Agent] instead of the Kubernetes kubelet.
-
 The docs can be found in the `docs` subdirectory, and they are published together with docs for all other Stackable products at https://docs.stackable.tech.

--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -54,7 +54,6 @@ properties:
       asOfVersion: "0.0.0"
       description: "The mode the cluster will be in. Possible values are false for standalone mode and true for distributed mode. If false, startup will run all HBase and ZooKeeper daemons together in the one JVM."
 
-
   - property: &hbaseMasterPort
       propertyNames:
         - name: "hbase.master.port"

--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -150,19 +150,3 @@ properties:
           required: false
       asOfVersion: "0.0.0"
       description: "The port where hbase metrics are exposed as a Prometheus endpoint."
-
-  - property: &javaHome
-      propertyNames:
-        - name: "JAVA_HOME"
-          kind:
-            type: "env"
-      datatype:
-        type: "string"
-        unit: *unitDirectory
-      roles:
-        - name: "master"
-          required: true
-        - name: "regionserver"
-          required: true
-      asOfVersion: "0.0.0"
-      description: "Points to the Java installation folder."

--- a/deploy/crd/hbasecluster.crd.yaml
+++ b/deploy/crd/hbasecluster.crd.yaml
@@ -46,9 +46,6 @@ spec:
                     config:
                       nullable: true
                       properties:
-                        javaHome:
-                          nullable: true
-                          type: string
                         masterPort:
                           format: uint16
                           minimum: 0.0
@@ -96,9 +93,6 @@ spec:
                           config:
                             nullable: true
                             properties:
-                              javaHome:
-                                nullable: true
-                                type: string
                               masterPort:
                                 format: uint16
                                 minimum: 0.0
@@ -186,9 +180,6 @@ spec:
                     config:
                       nullable: true
                       properties:
-                        javaHome:
-                          nullable: true
-                          type: string
                         masterPort:
                           format: uint16
                           minimum: 0.0
@@ -236,9 +227,6 @@ spec:
                           config:
                             nullable: true
                             properties:
-                              javaHome:
-                                nullable: true
-                                type: string
                               masterPort:
                                 format: uint16
                                 minimum: 0.0

--- a/docs/modules/ROOT/pages/building.adoc
+++ b/docs/modules/ROOT/pages/building.adoc
@@ -1,6 +1,6 @@
 = Building the Operator
 
 This operator is written in Rust.
-It is developed against the latest stable Rust release (1.54 at the time of writing).
+It is developed against the latest stable Rust release (1.56 at the time of writing).
 
     cargo build

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -2,4 +2,9 @@
 
 This is an operator for Kubernetes that can manage https://https://hbase.apache.org/[Apache HBase] clusters.
 
-WARNING: This operator does _not_ work with containers/container images. It relies on the https://github.com/stackabletech/agent/[Stackable Agent] to run on "bare metal" via systemd.
+WARNING: This operator only works with images from the https://repo.stackable.tech/#browse/browse:docker:v2%2Fstackable%2Fhbase[Stackable] repository
+
+[source]
+----
+docker pull docker.stackable.tech/stackable/hbase:<version>
+----

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -45,3 +45,10 @@ To create a single node Apache HBase (v2.4.6) cluster with Prometheus metrics ex
               regionServerWebUiPort: 17001
               metricsPort: 9708
     EOF
+
+If you set up an HBase service for the first time, you might need to create the `/hbase` folder after the pods are created:
+
+    export HADOOP_USER_NAME=root
+    ./hdfs dfs -mkdir hdfs://<namenode>:9000/hbase
+    ./hdfs dfs -chown stackable hdfs://<namenode>:9000/hbase
+

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -29,19 +29,19 @@ To create a single node Apache HBase (v2.4.6) cluster with Prometheus metrics ex
           default:
             selector:
               matchLabels:
-                kubernetes.io/arch: stackable-linux
+                kubernetes.io/os: linux
+            replicas: 1
             config:
-              javaHome: /usr/lib/jvm/java-1.11.0-openjdk-amd64/
               masterWebUiPort: 17000
-              metricsPort: 9505
+              metricsPort: 9707
       regionServers:
         roleGroups:
           default:
             selector:
               matchLabels:
-                kubernetes.io/arch: stackable-linux
+                kubernetes.io/os: linux
+            replicas: 1
             config:
-              javaHome: /usr/lib/jvm/java-1.11.0-openjdk-amd64/
               regionServerWebUiPort: 17001
-              metricsPort: 9506
+              metricsPort: 9708
     EOF

--- a/examples/simple-hbase-cluster.yaml
+++ b/examples/simple-hbase-cluster.yaml
@@ -16,20 +16,18 @@ spec:
       default:
         selector:
           matchLabels:
-            kubernetes.io/arch: stackable-linux
+            kubernetes.io/os: linux
         replicas: 1
         config:
-          javaHome: /usr/lib/jvm/java-1.11.0-openjdk-amd64/
           masterWebUiPort: 17000
-          metricsPort: 7077
+          metricsPort: 9707
   regionServers:
     roleGroups:
       default:
         selector:
           matchLabels:
-            kubernetes.io/arch: stackable-linux
-        replicas: 3
+            kubernetes.io/os: linux
+        replicas: 1
         config:
-          javaHome: /usr/lib/jvm/java-1.11.0-openjdk-amd64/
           regionServerWebUiPort: 17001
-          metricsPort: 7078
+          metricsPort: 9708

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -8,9 +8,9 @@ repository = "https://github.com/stackabletech/hbase-operator"
 version = "0.2.0-nightly"
 
 [dependencies]
-stackable-hdfs-crd = { git = "https://github.com/stackabletech/hdfs-operator.git", tag = "0.1.0"}
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.3.0" }
-stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-operator.git", tag = "0.4.1"}
+stackable-hdfs-crd = { git = "https://github.com/stackabletech/hdfs-operator.git", branch = "adapt_to_use_docker_image"}
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.4.0" }
+stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-operator.git", branch = "adapt_to_use_docker_image"}
 
 duplicate = "0.3.0"
 semver = "1.0"

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -8,9 +8,9 @@ repository = "https://github.com/stackabletech/hbase-operator"
 version = "0.2.0-nightly"
 
 [dependencies]
-stackable-hdfs-crd = { git = "https://github.com/stackabletech/hdfs-operator.git", branch = "adapt_to_use_docker_image"}
+stackable-hdfs-crd = { git = "https://github.com/stackabletech/hdfs-operator.git", tag = "0.2.0"}
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.4.0" }
-stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-operator.git", branch = "adapt_to_use_docker_image"}
+stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-operator.git", tag = "0.5.0"}
 
 duplicate = "0.3.0"
 semver = "1.0"

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -45,7 +45,6 @@ pub const HBASE_MASTER_WEB_UI_PORT: &str = "hbase.master.info.port";
 pub const HBASE_REGION_SERVER_PORT: &str = "hbase.regionserver.port";
 pub const HBASE_REGION_SERVER_WEB_UI_PORT: &str = "hbase.regionserver.info.port";
 
-pub const JAVA_HOME: &str = "JAVA_HOME";
 pub const METRICS_PORT: &str = "metricsPort";
 
 pub const HBASE_SITE_XML: &str = "hbase-site.xml";
@@ -97,13 +96,12 @@ pub enum HbaseRole {
 }
 
 impl HbaseRole {
-    pub fn command(&self, version: &HbaseVersion) -> String {
-        // TODO: test and fix command
-        format!(
-            "{}/bin/hbase {} start",
-            version.package_name(),
-            self.to_string()
-        )
+    pub fn command(&self) -> Vec<String> {
+        vec![
+            "bin/hbase".to_string(),
+            self.to_string(),
+            "start".to_string(),
+        ]
     }
 }
 
@@ -170,7 +168,6 @@ pub struct HbaseConfig {
     // region_server_web_ui_port can be set to -1 to disable the ui
     pub region_server_web_ui_port: Option<i16>,
     pub metrics_port: Option<u16>,
-    pub java_home: Option<String>,
 }
 
 impl Configuration for HbaseConfig {
@@ -182,10 +179,6 @@ impl Configuration for HbaseConfig {
         _role_name: &str,
     ) -> Result<BTreeMap<String, Option<String>>, ConfigError> {
         let mut result = BTreeMap::new();
-
-        if let Some(java_home) = &self.java_home {
-            result.insert(JAVA_HOME.to_string(), Some(java_home.to_string()));
-        }
 
         if let Some(metrics_port) = &self.metrics_port {
             result.insert(METRICS_PORT.to_string(), Some(metrics_port.to_string()));

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.2.0-nightly"
 build = "build.rs"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.3.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.4.0" }
 stackable-hbase-crd = { path = "../crd" }
 stackable-hbase-operator = { path = "../operator" }
 
@@ -19,7 +19,7 @@ tracing = "0.1"
 
 [build-dependencies]
 built = { version =  "0.5", features = ["chrono", "git2"] }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.3.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.4.0" }
 stackable-hbase-crd = { path = "../crd" }
 
 [package.metadata.deb]

--- a/rust/operator/Cargo.toml
+++ b/rust/operator/Cargo.toml
@@ -8,10 +8,10 @@ repository = "https://github.com/stackabletech/hbase-operator"
 version = "0.2.0-nightly"
 
 [dependencies]
-stackable-hdfs-crd = { git = "https://github.com/stackabletech/hdfs-operator.git", tag = "0.1.0"}
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.3.0" }
+stackable-hdfs-crd = { git = "https://github.com/stackabletech/hdfs-operator.git", branch = "adapt_to_use_docker_image"}
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.4.0" }
 stackable-hbase-crd = { path = "../crd" }
-stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-operator.git", tag = "0.4.1"}
+stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-operator.git", branch = "adapt_to_use_docker_image"}
 
 async-trait = "0.1"
 futures = "0.3"

--- a/rust/operator/Cargo.toml
+++ b/rust/operator/Cargo.toml
@@ -8,10 +8,10 @@ repository = "https://github.com/stackabletech/hbase-operator"
 version = "0.2.0-nightly"
 
 [dependencies]
-stackable-hdfs-crd = { git = "https://github.com/stackabletech/hdfs-operator.git", branch = "adapt_to_use_docker_image"}
+stackable-hdfs-crd = { git = "https://github.com/stackabletech/hdfs-operator.git", tag = "0.2.0"}
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.4.0" }
 stackable-hbase-crd = { path = "../crd" }
-stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-operator.git", branch = "adapt_to_use_docker_image"}
+stackable-zookeeper-crd = { git = "https://github.com/stackabletech/zookeeper-operator.git", tag = "0.5.0"}
 
 async-trait = "0.1"
 futures = "0.3"

--- a/rust/operator/src/lib.rs
+++ b/rust/operator/src/lib.rs
@@ -56,6 +56,10 @@ use strum::IntoEnumIterator;
 use tracing::error;
 use tracing::{debug, info, trace, warn};
 
+/// The docker image we default to. This needs to be adapted if the operator does not work
+/// with images 0.0.1, 0.1.0 etc. anymore and requires e.g. a new major version like 1(.0.0).
+const DEFAULT_IMAGE_VERSION: &str = "0";
+
 const FINALIZER_NAME: &str = "hbase.stackable.tech/cleanup";
 const ID_LABEL: &str = "hbase.stackable.tech/id";
 const SHOULD_BE_SCRAPED: &str = "monitoring.stackable.tech/should_be_scraped";
@@ -435,8 +439,9 @@ impl HbaseState {
         let mut container_builder = ContainerBuilder::new(APP_NAME);
         container_builder.image(format!(
             // TODO: how to handle the platform version?
-            "docker.stackable.tech/stackable/hbase:{}-0.1",
-            version.to_string()
+            "docker.stackable.tech/stackable/hbase:{}-stackable{}",
+            version.to_string(),
+            DEFAULT_IMAGE_VERSION
         ));
         container_builder.command(HbaseRole::from_str(pod_id.role())?.command());
 


### PR DESCRIPTION
## Description

fixes https://github.com/stackabletech/hbase-operator/issues/21

For testing we need to create hbase directory for now:
```
export HADOOP_USER_NAME=root
./hdfs dfs -mkdir hdfs://<namenode>:9000/hbase; ./hdfs dfs -chown stackable hdfs://<namenode>:9000/hbase
```
## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
