### PR TITLE
[Merged by Bors] - Support specifying a namespace to watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,15 @@
 ### Added
 
 - Support for HBase 2.4.9 ([#133]).
+- Use cli argument `watch-namespace` / env var `WATCH_NAMESPACE` to specify
+  a single namespace to watch ([#137]).
+
+## Changed
+
+- `operator-rs` `0.12.0` -> `0.13.0` ([#137]).
 
 [#133]: https://github.com/stackabletech/hbase-operator/pull/133
+[#137]: https://github.com/stackabletech/hbase-operator/pull/137
 
 ## [0.2.0] - 2022-02-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d76c22c9b9b215eeb8d016ad3a90417bd13cb24cf8142756e6472445876cab7"
+checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
 dependencies = [
  "atty",
  "bitflags",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd1122e63869df2cb309f449da1ad54a7c6dfeb7c7e6ccd8e0825d9eb93bb72"
+checksum = "01d42c94ce7c2252681b5fed4d3627cc807b13dfc033246bd05d5b252399000e"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -1502,7 +1502,6 @@ dependencies = [
  "serde_json",
  "stackable-operator",
  "strum 0.24.0",
- "strum_macros 0.24.0",
 ]
 
 [[package]]
@@ -1526,8 +1525,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.12.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.12.0#ac525b91421f7b0d4c74462627bf13e59be5661b"
+version = "0.13.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.13.0#401f4053d8c32d0fcd507d94799956181f66105d"
 dependencies = [
  "backoff",
  "chrono",

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,2 +1,3 @@
 * xref:installation.adoc[]
+* xref:configuration.adoc[]
 * xref:usage.adoc[]

--- a/docs/modules/ROOT/pages/commandline_args.adoc
+++ b/docs/modules/ROOT/pages/commandline_args.adoc
@@ -9,7 +9,7 @@
 
 [source]
 ----
-cargo run -- run --product-config /foo/bar/properties.yaml
+stackable-hbase-operator run --product-config /foo/bar/properties.yaml
 ----
 
 === watch-namespace
@@ -24,5 +24,5 @@ The operator will **only** watch for resources in the provided namespace `test`:
 
 [source]
 ----
-cargo run -- run --watch-namespace test
+stackable-hbase-operator run --watch-namespace test
 ----

--- a/docs/modules/ROOT/pages/commandline_args.adoc
+++ b/docs/modules/ROOT/pages/commandline_args.adoc
@@ -1,0 +1,28 @@
+
+=== product-config
+
+*Default value*: `/etc/stackable/hbase-operator/config-spec/properties.yaml`
+
+*Required*: false
+
+*Multiple values:* false
+
+[source]
+----
+cargo run -- run --product-config /foo/bar/properties.yaml
+----
+
+=== watch-namespace
+
+*Default value*: All namespaces
+
+*Required*: false
+
+*Multiple values:* false
+
+The operator will **only** watch for resources in the provided namespace `test`:
+
+[source]
+----
+cargo run -- run --watch-namespace test
+----

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -1,0 +1,13 @@
+= Configuration
+
+== Command Line Parameters
+
+This operator accepts the following command line parameters:
+
+include::commandline_args.adoc[]
+
+== Environment variables
+
+This operator accepts the following environment variables:
+
+include::env_var_args.adoc[]

--- a/docs/modules/ROOT/pages/env_var_args.adoc
+++ b/docs/modules/ROOT/pages/env_var_args.adoc
@@ -10,7 +10,7 @@
 [source]
 ----
 export PRODUCT_CONFIG=/foo/bar/properties.yaml
-cargo run -- run
+stackable-hbase-operator run
 ----
 
 or via docker:
@@ -38,7 +38,7 @@ The operator will **only** watch for resources in the provided namespace `test`:
 [source]
 ----
 export WATCH_NAMESPACE=test
-cargo run -- run
+stackable-hbase-operator run
 ----
 
 or via docker:

--- a/docs/modules/ROOT/pages/env_var_args.adoc
+++ b/docs/modules/ROOT/pages/env_var_args.adoc
@@ -1,0 +1,56 @@
+
+=== PRODUCT_CONFIG
+
+*Default value*: `/etc/stackable/hbase-operator/config-spec/properties.yaml`
+
+*Required*: false
+
+*Multiple values:* false
+
+[source]
+----
+export PRODUCT_CONFIG=/foo/bar/properties.yaml
+cargo run -- run
+----
+
+or via docker:
+
+----
+docker run \
+    --name hbase-operator \
+    --network host \
+    --env KUBECONFIG=/home/stackable/.kube/config \
+    --env PRODUCT_CONFIG=/my/product/config.yaml \
+    --mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
+    docker.stackable.tech/stackable/hbase-operator:latest
+----
+
+=== WATCH_NAMESPACE
+
+*Default value*: All namespaces
+
+*Required*: false
+
+*Multiple values:* false
+
+The operator will **only** watch for resources in the provided namespace `test`:
+
+[source]
+----
+export WATCH_NAMESPACE=test
+cargo run -- run
+----
+
+or via docker:
+
+[source]
+----
+docker run \
+--name hbase-operator \
+--network host \
+--env KUBECONFIG=/home/stackable/.kube/config \
+--env WATCH_NAMESPACE=test \
+--mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
+docker.stackable.tech/stackable/hbase-operator:latest
+----
+

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -62,6 +62,6 @@ the time of writing).
 
 [source]
 ----
-cargo run -- crd | kubectl apply -f -
-cargo run -- run
+stackable-hbase-operator crd | kubectl apply -f -
+stackable-hbase-operator run
 ----

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -10,6 +10,5 @@ version = "0.3.0-nightly"
 [dependencies]
 serde = "1.0"
 serde_json = "1.0"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.12.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
 strum = { version = "0.24", features = ["derive"] }
-strum_macros = "0.24"

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -6,8 +6,7 @@ use stackable_operator::kube::CustomResource;
 use stackable_operator::product_config_utils::{ConfigError, Configuration};
 use stackable_operator::role_utils::{Role, RoleGroupRef};
 use stackable_operator::schemars::{self, JsonSchema};
-use strum_macros::Display;
-use strum_macros::EnumIter;
+use strum::{Display, EnumIter};
 
 pub const APP_NAME: &str = "hbase";
 

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -16,7 +16,7 @@ serde = "1.0"
 serde_yaml = "0.8"
 snafu = "0.7"
 stackable-hbase-crd = { path = "../crd" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.12.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
 strum = { version = "0.24", features = ["derive"] }
 tokio = { version = "1.17", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
@@ -24,4 +24,4 @@ tracing = "0.1"
 [build-dependencies]
 built = { version =  "0.5", features = ["chrono", "git2"] }
 stackable-hbase-crd = { path = "../crd" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.12.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -32,7 +32,10 @@ async fn main() -> anyhow::Result<()> {
     let opts = Opts::parse();
     match opts.cmd {
         Command::Crd => println!("{}", serde_yaml::to_string(&HbaseCluster::crd())?,),
-        Command::Run(ProductOperatorRun { product_config }) => {
+        Command::Run(ProductOperatorRun {
+            product_config,
+            watch_namespace,
+        }) => {
             stackable_operator::utils::print_startup_string(
                 built_info::PKG_DESCRIPTION,
                 built_info::PKG_VERSION,
@@ -49,27 +52,32 @@ async fn main() -> anyhow::Result<()> {
                 stackable_operator::client::create_client(Some("hbase.stackable.tech".to_string()))
                     .await?;
 
-            Controller::new(client.get_all_api::<HbaseCluster>(), ListParams::default())
-                .owns(client.get_all_api::<Service>(), ListParams::default())
-                .owns(client.get_all_api::<StatefulSet>(), ListParams::default())
-                .shutdown_on_signal()
-                .run(
-                    hbase_controller::reconcile_hbase,
-                    hbase_controller::error_policy,
-                    Context::new(hbase_controller::Ctx {
-                        client: client.clone(),
-                        product_config,
-                    }),
-                )
-                .map(|res| {
-                    report_controller_reconciled(
-                        &client,
-                        "hbaseclusters.hbase.stackable.tech",
-                        &res,
-                    )
-                })
-                .collect::<()>()
-                .await;
+            Controller::new(
+                watch_namespace.get_api::<HbaseCluster>(&client),
+                ListParams::default(),
+            )
+            .owns(
+                watch_namespace.get_api::<Service>(&client),
+                ListParams::default(),
+            )
+            .owns(
+                watch_namespace.get_api::<StatefulSet>(&client),
+                ListParams::default(),
+            )
+            .shutdown_on_signal()
+            .run(
+                hbase_controller::reconcile_hbase,
+                hbase_controller::error_policy,
+                Context::new(hbase_controller::Ctx {
+                    client: client.clone(),
+                    product_config,
+                }),
+            )
+            .map(|res| {
+                report_controller_reconciled(&client, "hbaseclusters.hbase.stackable.tech", &res)
+            })
+            .collect::<()>()
+            .await;
         }
     }
 


### PR DESCRIPTION
## Description

try
```
cargo run -- run --watch-namespace test
```
or
```
export WATCH_NAMESPACE=test
cargo run -- run
```

fixes https://github.com/stackabletech/hbase-operator/issues/136

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
