### PR TITLE
Enable service discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 - `operator-rs` `0.12.0` -> `0.15.0` ([#137], [#153]).
 - Now using HDFS discovery config map instead of hdfs name node config map ([#153])
-- BREAKING: Consolidated CRD - discovery config maps now top level, removed several `HbaseConfig` options ([#162]). 
+- BREAKING: Consolidated CRD - discovery config maps now top level, removed several `HbaseConfig` options ([#162]).
 
 [#133]: https://github.com/stackabletech/hbase-operator/pull/133
 [#137]: https://github.com/stackabletech/hbase-operator/pull/137

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@
 
 - `operator-rs` `0.12.0` -> `0.15.0` ([#137], [#153]).
 - Now using HDFS discovery config map instead of hdfs name node config map ([#153])
+- BREAKING: Consolidated CRD - discovery config maps now top level, removed several `HbaseConfig` options ([#162]). 
 
 [#133]: https://github.com/stackabletech/hbase-operator/pull/133
 [#137]: https://github.com/stackabletech/hbase-operator/pull/137
 [#148]: https://github.com/stackabletech/hbase-operator/pull/148
 [#153]: https://github.com/stackabletech/hbase-operator/pull/153
+[#162]: https://github.com/stackabletech/hbase-operator/pull/162
 
 ## [0.2.0] - 2022-02-14
 

--- a/deploy/crd/hbasecluster.crd.yaml
+++ b/deploy/crd/hbasecluster.crd.yaml
@@ -25,31 +25,15 @@ spec:
                 config:
                   nullable: true
                   properties:
-                    hbaseClusterDistributed:
-                      nullable: true
-                      type: boolean
-                    hbaseManagesZk:
-                      nullable: true
-                      type: boolean
                     hbaseOpts:
                       nullable: true
                       type: string
                     hbaseRootdir:
                       nullable: true
                       type: string
-                    hbaseZookeeperQuorum:
-                      nullable: true
-                      type: string
-                    hdfsConfig:
-                      nullable: true
-                      type: string
-                    hdfsConfigMapName:
-                      nullable: true
-                      type: string
-                    zookeeperConfigMapName:
-                      nullable: true
-                      type: string
                   type: object
+                hdfsConfigMapName:
+                  type: string
                 masters:
                   nullable: true
                   properties:
@@ -61,28 +45,10 @@ spec:
                     config:
                       default: {}
                       properties:
-                        hbaseClusterDistributed:
-                          nullable: true
-                          type: boolean
-                        hbaseManagesZk:
-                          nullable: true
-                          type: boolean
                         hbaseOpts:
                           nullable: true
                           type: string
                         hbaseRootdir:
-                          nullable: true
-                          type: string
-                        hbaseZookeeperQuorum:
-                          nullable: true
-                          type: string
-                        hdfsConfig:
-                          nullable: true
-                          type: string
-                        hdfsConfigMapName:
-                          nullable: true
-                          type: string
-                        zookeeperConfigMapName:
                           nullable: true
                           type: string
                       type: object
@@ -109,28 +75,10 @@ spec:
                           config:
                             default: {}
                             properties:
-                              hbaseClusterDistributed:
-                                nullable: true
-                                type: boolean
-                              hbaseManagesZk:
-                                nullable: true
-                                type: boolean
                               hbaseOpts:
                                 nullable: true
                                 type: string
                               hbaseRootdir:
-                                nullable: true
-                                type: string
-                              hbaseZookeeperQuorum:
-                                nullable: true
-                                type: string
-                              hdfsConfig:
-                                nullable: true
-                                type: string
-                              hdfsConfigMapName:
-                                nullable: true
-                                type: string
-                              zookeeperConfigMapName:
                                 nullable: true
                                 type: string
                             type: object
@@ -198,28 +146,10 @@ spec:
                     config:
                       default: {}
                       properties:
-                        hbaseClusterDistributed:
-                          nullable: true
-                          type: boolean
-                        hbaseManagesZk:
-                          nullable: true
-                          type: boolean
                         hbaseOpts:
                           nullable: true
                           type: string
                         hbaseRootdir:
-                          nullable: true
-                          type: string
-                        hbaseZookeeperQuorum:
-                          nullable: true
-                          type: string
-                        hdfsConfig:
-                          nullable: true
-                          type: string
-                        hdfsConfigMapName:
-                          nullable: true
-                          type: string
-                        zookeeperConfigMapName:
                           nullable: true
                           type: string
                       type: object
@@ -246,28 +176,10 @@ spec:
                           config:
                             default: {}
                             properties:
-                              hbaseClusterDistributed:
-                                nullable: true
-                                type: boolean
-                              hbaseManagesZk:
-                                nullable: true
-                                type: boolean
                               hbaseOpts:
                                 nullable: true
                                 type: string
                               hbaseRootdir:
-                                nullable: true
-                                type: string
-                              hbaseZookeeperQuorum:
-                                nullable: true
-                                type: string
-                              hdfsConfig:
-                                nullable: true
-                                type: string
-                              hdfsConfigMapName:
-                                nullable: true
-                                type: string
-                              zookeeperConfigMapName:
                                 nullable: true
                                 type: string
                             type: object
@@ -335,28 +247,10 @@ spec:
                     config:
                       default: {}
                       properties:
-                        hbaseClusterDistributed:
-                          nullable: true
-                          type: boolean
-                        hbaseManagesZk:
-                          nullable: true
-                          type: boolean
                         hbaseOpts:
                           nullable: true
                           type: string
                         hbaseRootdir:
-                          nullable: true
-                          type: string
-                        hbaseZookeeperQuorum:
-                          nullable: true
-                          type: string
-                        hdfsConfig:
-                          nullable: true
-                          type: string
-                        hdfsConfigMapName:
-                          nullable: true
-                          type: string
-                        zookeeperConfigMapName:
                           nullable: true
                           type: string
                       type: object
@@ -383,28 +277,10 @@ spec:
                           config:
                             default: {}
                             properties:
-                              hbaseClusterDistributed:
-                                nullable: true
-                                type: boolean
-                              hbaseManagesZk:
-                                nullable: true
-                                type: boolean
                               hbaseOpts:
                                 nullable: true
                                 type: string
                               hbaseRootdir:
-                                nullable: true
-                                type: string
-                              hbaseZookeeperQuorum:
-                                nullable: true
-                                type: string
-                              hdfsConfig:
-                                nullable: true
-                                type: string
-                              hdfsConfigMapName:
-                                nullable: true
-                                type: string
-                              zookeeperConfigMapName:
                                 nullable: true
                                 type: string
                             type: object
@@ -469,6 +345,11 @@ spec:
                   description: Desired HBase version
                   nullable: true
                   type: string
+                zookeeperConfigMapName:
+                  type: string
+              required:
+                - hdfsConfigMapName
+                - zookeeperConfigMapName
               type: object
             status:
               nullable: true

--- a/deploy/helm/hbase-operator/crds/crds.yaml
+++ b/deploy/helm/hbase-operator/crds/crds.yaml
@@ -27,31 +27,15 @@ spec:
                 config:
                   nullable: true
                   properties:
-                    hbaseClusterDistributed:
-                      nullable: true
-                      type: boolean
-                    hbaseManagesZk:
-                      nullable: true
-                      type: boolean
                     hbaseOpts:
                       nullable: true
                       type: string
                     hbaseRootdir:
                       nullable: true
                       type: string
-                    hbaseZookeeperQuorum:
-                      nullable: true
-                      type: string
-                    hdfsConfig:
-                      nullable: true
-                      type: string
-                    hdfsConfigMapName:
-                      nullable: true
-                      type: string
-                    zookeeperConfigMapName:
-                      nullable: true
-                      type: string
                   type: object
+                hdfsConfigMapName:
+                  type: string
                 masters:
                   nullable: true
                   properties:
@@ -63,28 +47,10 @@ spec:
                     config:
                       default: {}
                       properties:
-                        hbaseClusterDistributed:
-                          nullable: true
-                          type: boolean
-                        hbaseManagesZk:
-                          nullable: true
-                          type: boolean
                         hbaseOpts:
                           nullable: true
                           type: string
                         hbaseRootdir:
-                          nullable: true
-                          type: string
-                        hbaseZookeeperQuorum:
-                          nullable: true
-                          type: string
-                        hdfsConfig:
-                          nullable: true
-                          type: string
-                        hdfsConfigMapName:
-                          nullable: true
-                          type: string
-                        zookeeperConfigMapName:
                           nullable: true
                           type: string
                       type: object
@@ -111,28 +77,10 @@ spec:
                           config:
                             default: {}
                             properties:
-                              hbaseClusterDistributed:
-                                nullable: true
-                                type: boolean
-                              hbaseManagesZk:
-                                nullable: true
-                                type: boolean
                               hbaseOpts:
                                 nullable: true
                                 type: string
                               hbaseRootdir:
-                                nullable: true
-                                type: string
-                              hbaseZookeeperQuorum:
-                                nullable: true
-                                type: string
-                              hdfsConfig:
-                                nullable: true
-                                type: string
-                              hdfsConfigMapName:
-                                nullable: true
-                                type: string
-                              zookeeperConfigMapName:
                                 nullable: true
                                 type: string
                             type: object
@@ -200,28 +148,10 @@ spec:
                     config:
                       default: {}
                       properties:
-                        hbaseClusterDistributed:
-                          nullable: true
-                          type: boolean
-                        hbaseManagesZk:
-                          nullable: true
-                          type: boolean
                         hbaseOpts:
                           nullable: true
                           type: string
                         hbaseRootdir:
-                          nullable: true
-                          type: string
-                        hbaseZookeeperQuorum:
-                          nullable: true
-                          type: string
-                        hdfsConfig:
-                          nullable: true
-                          type: string
-                        hdfsConfigMapName:
-                          nullable: true
-                          type: string
-                        zookeeperConfigMapName:
                           nullable: true
                           type: string
                       type: object
@@ -248,28 +178,10 @@ spec:
                           config:
                             default: {}
                             properties:
-                              hbaseClusterDistributed:
-                                nullable: true
-                                type: boolean
-                              hbaseManagesZk:
-                                nullable: true
-                                type: boolean
                               hbaseOpts:
                                 nullable: true
                                 type: string
                               hbaseRootdir:
-                                nullable: true
-                                type: string
-                              hbaseZookeeperQuorum:
-                                nullable: true
-                                type: string
-                              hdfsConfig:
-                                nullable: true
-                                type: string
-                              hdfsConfigMapName:
-                                nullable: true
-                                type: string
-                              zookeeperConfigMapName:
                                 nullable: true
                                 type: string
                             type: object
@@ -337,28 +249,10 @@ spec:
                     config:
                       default: {}
                       properties:
-                        hbaseClusterDistributed:
-                          nullable: true
-                          type: boolean
-                        hbaseManagesZk:
-                          nullable: true
-                          type: boolean
                         hbaseOpts:
                           nullable: true
                           type: string
                         hbaseRootdir:
-                          nullable: true
-                          type: string
-                        hbaseZookeeperQuorum:
-                          nullable: true
-                          type: string
-                        hdfsConfig:
-                          nullable: true
-                          type: string
-                        hdfsConfigMapName:
-                          nullable: true
-                          type: string
-                        zookeeperConfigMapName:
                           nullable: true
                           type: string
                       type: object
@@ -385,28 +279,10 @@ spec:
                           config:
                             default: {}
                             properties:
-                              hbaseClusterDistributed:
-                                nullable: true
-                                type: boolean
-                              hbaseManagesZk:
-                                nullable: true
-                                type: boolean
                               hbaseOpts:
                                 nullable: true
                                 type: string
                               hbaseRootdir:
-                                nullable: true
-                                type: string
-                              hbaseZookeeperQuorum:
-                                nullable: true
-                                type: string
-                              hdfsConfig:
-                                nullable: true
-                                type: string
-                              hdfsConfigMapName:
-                                nullable: true
-                                type: string
-                              zookeeperConfigMapName:
                                 nullable: true
                                 type: string
                             type: object
@@ -471,6 +347,11 @@ spec:
                   description: Desired HBase version
                   nullable: true
                   type: string
+                zookeeperConfigMapName:
+                  type: string
+              required:
+                - hdfsConfigMapName
+                - zookeeperConfigMapName
               type: object
             status:
               nullable: true

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -28,31 +28,15 @@ spec:
                 config:
                   nullable: true
                   properties:
-                    hbaseClusterDistributed:
-                      nullable: true
-                      type: boolean
-                    hbaseManagesZk:
-                      nullable: true
-                      type: boolean
                     hbaseOpts:
                       nullable: true
                       type: string
                     hbaseRootdir:
                       nullable: true
                       type: string
-                    hbaseZookeeperQuorum:
-                      nullable: true
-                      type: string
-                    hdfsConfig:
-                      nullable: true
-                      type: string
-                    hdfsConfigMapName:
-                      nullable: true
-                      type: string
-                    zookeeperConfigMapName:
-                      nullable: true
-                      type: string
                   type: object
+                hdfsConfigMapName:
+                  type: string
                 masters:
                   nullable: true
                   properties:
@@ -64,28 +48,10 @@ spec:
                     config:
                       default: {}
                       properties:
-                        hbaseClusterDistributed:
-                          nullable: true
-                          type: boolean
-                        hbaseManagesZk:
-                          nullable: true
-                          type: boolean
                         hbaseOpts:
                           nullable: true
                           type: string
                         hbaseRootdir:
-                          nullable: true
-                          type: string
-                        hbaseZookeeperQuorum:
-                          nullable: true
-                          type: string
-                        hdfsConfig:
-                          nullable: true
-                          type: string
-                        hdfsConfigMapName:
-                          nullable: true
-                          type: string
-                        zookeeperConfigMapName:
                           nullable: true
                           type: string
                       type: object
@@ -112,28 +78,10 @@ spec:
                           config:
                             default: {}
                             properties:
-                              hbaseClusterDistributed:
-                                nullable: true
-                                type: boolean
-                              hbaseManagesZk:
-                                nullable: true
-                                type: boolean
                               hbaseOpts:
                                 nullable: true
                                 type: string
                               hbaseRootdir:
-                                nullable: true
-                                type: string
-                              hbaseZookeeperQuorum:
-                                nullable: true
-                                type: string
-                              hdfsConfig:
-                                nullable: true
-                                type: string
-                              hdfsConfigMapName:
-                                nullable: true
-                                type: string
-                              zookeeperConfigMapName:
                                 nullable: true
                                 type: string
                             type: object
@@ -201,28 +149,10 @@ spec:
                     config:
                       default: {}
                       properties:
-                        hbaseClusterDistributed:
-                          nullable: true
-                          type: boolean
-                        hbaseManagesZk:
-                          nullable: true
-                          type: boolean
                         hbaseOpts:
                           nullable: true
                           type: string
                         hbaseRootdir:
-                          nullable: true
-                          type: string
-                        hbaseZookeeperQuorum:
-                          nullable: true
-                          type: string
-                        hdfsConfig:
-                          nullable: true
-                          type: string
-                        hdfsConfigMapName:
-                          nullable: true
-                          type: string
-                        zookeeperConfigMapName:
                           nullable: true
                           type: string
                       type: object
@@ -249,28 +179,10 @@ spec:
                           config:
                             default: {}
                             properties:
-                              hbaseClusterDistributed:
-                                nullable: true
-                                type: boolean
-                              hbaseManagesZk:
-                                nullable: true
-                                type: boolean
                               hbaseOpts:
                                 nullable: true
                                 type: string
                               hbaseRootdir:
-                                nullable: true
-                                type: string
-                              hbaseZookeeperQuorum:
-                                nullable: true
-                                type: string
-                              hdfsConfig:
-                                nullable: true
-                                type: string
-                              hdfsConfigMapName:
-                                nullable: true
-                                type: string
-                              zookeeperConfigMapName:
                                 nullable: true
                                 type: string
                             type: object
@@ -338,28 +250,10 @@ spec:
                     config:
                       default: {}
                       properties:
-                        hbaseClusterDistributed:
-                          nullable: true
-                          type: boolean
-                        hbaseManagesZk:
-                          nullable: true
-                          type: boolean
                         hbaseOpts:
                           nullable: true
                           type: string
                         hbaseRootdir:
-                          nullable: true
-                          type: string
-                        hbaseZookeeperQuorum:
-                          nullable: true
-                          type: string
-                        hdfsConfig:
-                          nullable: true
-                          type: string
-                        hdfsConfigMapName:
-                          nullable: true
-                          type: string
-                        zookeeperConfigMapName:
                           nullable: true
                           type: string
                       type: object
@@ -386,28 +280,10 @@ spec:
                           config:
                             default: {}
                             properties:
-                              hbaseClusterDistributed:
-                                nullable: true
-                                type: boolean
-                              hbaseManagesZk:
-                                nullable: true
-                                type: boolean
                               hbaseOpts:
                                 nullable: true
                                 type: string
                               hbaseRootdir:
-                                nullable: true
-                                type: string
-                              hbaseZookeeperQuorum:
-                                nullable: true
-                                type: string
-                              hdfsConfig:
-                                nullable: true
-                                type: string
-                              hdfsConfigMapName:
-                                nullable: true
-                                type: string
-                              zookeeperConfigMapName:
                                 nullable: true
                                 type: string
                             type: object
@@ -472,6 +348,11 @@ spec:
                   description: Desired HBase version
                   nullable: true
                   type: string
+                zookeeperConfigMapName:
+                  type: string
+              required:
+                - hdfsConfigMapName
+                - zookeeperConfigMapName
               type: object
             status:
               nullable: true

--- a/docs/modules/ROOT/pages/discovery.adoc
+++ b/docs/modules/ROOT/pages/discovery.adoc
@@ -1,0 +1,38 @@
+:clusterName: \{clusterName\}
+:namespace: \{namespace\}
+
+= Discovery
+
+The Stackable Operator for Apache HBase publishes a discovery https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmap-v1-core[`ConfigMap`], which exposes a client configuration bundle that allows access to the Apache HBase cluster.
+
+== Example
+
+Given the following HBase cluster:
+
+[source,yaml,subs="normal,callouts"]
+----
+apiVersion: hbase.stackable.tech/v1alpha1
+kind: HbaseCluster
+metadata:
+  name: {clusterName} # <1>
+  namespace: {namespace} # <2>
+spec:
+  hdfsConfigMapName: {hdfs-cluster-name} #<3>
+  zookeeperConfigMapName: {zookeeper-znode-name} #<4>
+  config:
+    hbaseRootdir: /hbase
+  [...]
+----
+<1> The name of the HBase cluster, which is also the name of the created discovery `ConfigMap`.
+<2> The namespace of the discovery `ConfigMap`.
+<3> The `ConfigMap` name to discover the HDFS cluster.
+<4> The `ConfigMap` name to discover the ZooKeeper cluster.
+
+The resulting discovery `ConfigMap` is located at `{namespace}/{clusterName}`.
+
+== Contents
+
+The `ConfigMap` data values are formatted as Hadoop XML files which allows simple mounting of that ConfigMap into pods that require access to HBase.
+
+`hbase-site.xml`::
+Contains the `hbase.zookeeper.quorum` property.

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -18,12 +18,9 @@ metadata:
   name: simple-hbase
 spec:
   version: 2.4.11
+  hdfsConfigMapName: simple-hdfs-namenode-default
+  zookeeperConfigMapName: simple-hbase-znode
   config:
-    hdfsConfigMapName: simple-hdfs-namenode-default
-    zookeeperConfigMapName: simple-hbase-znode
-    hbaseManagesZk: false
-    hbaseOpts:
-    hbaseClusterDistributed: true
     hbaseRootdir: hdfs://simple-hdfs/hbase
   masters:
     roleGroups:
@@ -59,12 +56,6 @@ spec:
 `hdfsConfigMapName` references the config map created by the Stackable HDFS operator.
 
 `zookeeperConfigMapName` references the config map created by the Stackable ZooKeeper operator.
-
-`hbaseManagesZk` is mapped to the environment variable `HBASE_MANAGES_ZK` in `hbase-env.sh`.
-
-`hbaseOpts` is mapped to the environment variable `HBASE_OPTS` in `hbase-env.sh`.
-
-`hbaseClusterDistributed` is mapped to `hbase.cluster.distributed` in `hbase-site.xml`.
 
 `hbaseRootdir` is mapped to `hbase.rootdir` in `hbase-site.xml`.
 

--- a/examples/simple-hbase-cluster.yaml
+++ b/examples/simple-hbase-cluster.yaml
@@ -11,6 +11,14 @@ spec:
   version: 3.5.8
   stopped: false
 ---
+apiVersion: zookeeper.stackable.tech/v1alpha1
+kind: ZookeeperZnode
+metadata:
+  name: simple-hdfs-znode
+spec:
+  clusterRef:
+    name: simple-zk
+---
 apiVersion: hdfs.stackable.tech/v1alpha1
 kind: HdfsCluster
 metadata:
@@ -58,7 +66,7 @@ spec:
 apiVersion: zookeeper.stackable.tech/v1alpha1
 kind: ZookeeperZnode
 metadata:
-  name: simple-hdfs-znode
+  name: simple-hbase-znode
 spec:
   clusterRef:
     name: simple-zk
@@ -69,12 +77,9 @@ metadata:
   name: simple-hbase
 spec:
   version: 2.4.11
+  hdfsConfigMapName: simple-hdfs
+  zookeeperConfigMapName: simple-hbase-znode
   config:
-    hdfsConfigMapName: simple-hdfs
-    zookeeperConfigMapName: simple-hbase-znode
-    hbaseManagesZk: false
-    hbaseOpts:
-    hbaseClusterDistributed: true
     hbaseRootdir: /hbase
   masters:
     roleGroups:
@@ -97,11 +102,3 @@ spec:
           matchLabels:
             kubernetes.io/os: linux
         replicas: 1
----
-apiVersion: zookeeper.stackable.tech/v1alpha1
-kind: ZookeeperZnode
-metadata:
-  name: simple-hbase-znode
-spec:
-  clusterRef:
-    name: simple-zk

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -159,15 +159,7 @@ impl Configuration for HbaseConfig {
                     HBASE_CLUSTER_DISTRIBUTED.to_string(),
                     Some("true".to_string()),
                 );
-                result.insert(
-                    HBASE_ROOTDIR.to_string(),
-                    Some(
-                        self.hbase_rootdir
-                            .as_deref()
-                            .unwrap_or("/hbase")
-                            .to_string(),
-                    ),
-                );
+                result.insert(HBASE_ROOTDIR.to_string(), Some(resource.root_dir()));
             }
             _ => {}
         }
@@ -207,5 +199,14 @@ impl HbaseCluster {
             HbaseRole::RegionServer => self.spec.region_servers.as_ref(),
             HbaseRole::RestServer => self.spec.rest_servers.as_ref(),
         }
+    }
+
+    pub fn root_dir(&self) -> String {
+        self.spec
+            .config
+            .as_ref()
+            .and_then(|c| c.hbase_rootdir.as_deref())
+            .unwrap_or("/hbase")
+            .to_string()
     }
 }

--- a/rust/operator-binary/src/discovery.rs
+++ b/rust/operator-binary/src/discovery.rs
@@ -1,0 +1,42 @@
+use crate::hbase_controller::hbase_version;
+use stackable_hbase_crd::{
+    HbaseCluster, HbaseRole, APP_NAME, HBASE_SITE_XML, HBASE_ZOOKEEPER_QUORUM,
+};
+use stackable_operator::{
+    builder::{ConfigMapBuilder, ObjectMetaBuilder},
+    error::{Error, OperatorResult},
+    k8s_openapi::api::core::v1::ConfigMap,
+};
+use std::collections::HashMap;
+
+/// Creates a discovery config map containing the `hbase-site.xml` for clients.
+pub fn build_discovery_configmap(
+    hbase: &HbaseCluster,
+    zookeeper_connect_string: &str,
+) -> OperatorResult<ConfigMap> {
+    let hbase_site_data: HashMap<String, Option<String>> = [(
+        HBASE_ZOOKEEPER_QUORUM.to_string(),
+        Some(zookeeper_connect_string.to_string()),
+    )]
+    .into();
+
+    ConfigMapBuilder::new()
+        .metadata(
+            ObjectMetaBuilder::new()
+                .name_and_namespace(hbase)
+                .ownerreference_from_resource(hbase, None, Some(true))?
+                .with_recommended_labels(
+                    hbase,
+                    APP_NAME,
+                    hbase_version(hbase).map_err(|_| Error::MissingObjectKey { key: "version" })?,
+                    &HbaseRole::RegionServer.to_string(),
+                    "discovery",
+                )
+                .build(),
+        )
+        .add_data(
+            HBASE_SITE_XML,
+            stackable_operator::product_config::writer::to_hadoop_xml(hbase_site_data.iter()),
+        )
+        .build()
+}

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -1,3 +1,4 @@
+mod discovery;
 mod hbase_controller;
 
 use clap::Parser;


### PR DESCRIPTION
## Description

- writes a configmap which exposes the `hbase-site.xml` and the required zookeeper quorum.

based on https://github.com/stackabletech/hbase-operator/pull/162

closes https://github.com/stackabletech/hbase-operator/issues/151

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
