### PR TITLE
[Merged by Bors] - Add startup probe and fine-tune values in liveness and readiness probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   - `hbaseManagesZk`: defaults to false
   - `hbaseClusterDistributed`: defaults to true
 - [BREAKING] Specifying the product version has been changed to adhere to [ADR018](https://docs.stackable.tech/home/contributor/adr/ADR018-product_image_versioning.html) instead of just specifying the product version you will now have to add the Stackable image version as well, so `version: 3.5.8` becomes (for example) `version: 3.5.8-stackable0.1.0` ([#179])
+- Startup probe created and thresholds in liveness and readiness probes fine-tuned ([#193]).
 
 [#133]: https://github.com/stackabletech/hbase-operator/pull/133
 [#137]: https://github.com/stackabletech/hbase-operator/pull/137
@@ -29,6 +30,7 @@
 [#162]: https://github.com/stackabletech/hbase-operator/pull/162
 [#163]: https://github.com/stackabletech/hbase-operator/pull/163
 [#179]: https://github.com/stackabletech/hbase-operator/pull/179
+[#193]: https://github.com/stackabletech/hbase-operator/pull/193
 [#197]: https://github.com/stackabletech/hbase-operator/pull/197
 
 ## [0.2.0] - 2022-02-14


### PR DESCRIPTION
# Description

Add startup probe and fine-tune values in liveness and readiness probes

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Integration tests

* K3s on Hetzner Cloud, v1.23
[![Build Status](https://ci.stackable.tech/buildStatus/icon?job=hbase-operator-it-custom&build=14)](https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/hbase-operator-it-custom/14/)

* Microsoft Azure AKS, 1.24.0
[![Build Status](https://ci.stackable.tech/buildStatus/icon?job=hbase-operator-it-custom&build=12)](https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/hbase-operator-it-custom/12/)

* IONOS managed K8s, 1.23.8
[![Build Status](https://ci.stackable.tech/buildStatus/icon?job=hbase-operator-it-custom&build=13)](https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/hbase-operator-it-custom/13/)

## Review Checklist

- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
