### PR TITLE
Fix Asciidoc error

### DIFF
--- a/docs/modules/ROOT/pages/discovery.adoc
+++ b/docs/modules/ROOT/pages/discovery.adoc
@@ -17,8 +17,8 @@ metadata:
   name: {clusterName} # <1>
   namespace: {namespace} # <2>
 spec:
-  hdfsConfigMapName: {hdfs-cluster-name} #<3>
-  zookeeperConfigMapName: {zookeeper-znode-name} #<4>
+  hdfsConfigMapName: \{hdfs-cluster-name} #<3>
+  zookeeperConfigMapName: \{zookeeper-znode-name} #<4>
   config:
     hbaseRootdir: /hbase
 ----


### PR DESCRIPTION
# Description

This would trigger this warning:

[19:27:49.917] WARN (asciidoctor): skipping reference to missing attribute: hdfs-cluster-name
    file: docs/modules/ROOT/pages/discovery.adoc
    source: https://github.com/stackabletech/hbase-operator.git (refname: docs/0.3, start path: docs)

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
