### PR TITLE
[Merged by Bors] - use non-HBASE_OPTS for jmx setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 ## Changed
 
 - Include chart name when installing with a custom release name ([#209], [#210]).
+- Fix HBase-shell start failure ([#218]).
 
 [#209]: https://github.com/stackabletech/hbase-operator/pull/209
 [#210]: https://github.com/stackabletech/hbase-operator/pull/210
+[#218]: https://github.com/stackabletech/hbase-operator/pull/218
 
 ## [0.3.0] - 2022-06-30
 

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -1,12 +1,10 @@
-use std::collections::BTreeMap;
-use std::str::FromStr;
-
 use serde::{Deserialize, Serialize};
 use stackable_operator::kube::runtime::reflector::ObjectRef;
 use stackable_operator::kube::CustomResource;
 use stackable_operator::product_config_utils::{ConfigError, Configuration};
 use stackable_operator::role_utils::{Role, RoleGroupRef};
 use stackable_operator::schemars::{self, JsonSchema};
+use std::collections::BTreeMap;
 use strum::{Display, EnumIter, EnumString};
 
 pub const APP_NAME: &str = "hbase";
@@ -16,7 +14,8 @@ pub const HBASE_SITE_XML: &str = "hbase-site.xml";
 
 pub const HBASE_MANAGES_ZK: &str = "HBASE_MANAGES_ZK";
 pub const HBASE_MASTER_OPTS: &str = "HBASE_MASTER_OPTS";
-pub const BASE_REGIONSERVER_OPTS: &str = "BASE_REGIONSERVER_OPTS";
+pub const HBASE_REGIONSERVER_OPTS: &str = "HBASE_REGIONSERVER_OPTS";
+pub const HBASE_REST_OPTS: &str = "HBASE_REST_OPTS";
 
 pub const HBASE_CLUSTER_DISTRIBUTED: &str = "hbase.cluster.distributed";
 pub const HBASE_ROOTDIR: &str = "hbase.rootdir";
@@ -164,28 +163,14 @@ impl Configuration for HbaseConfig {
                     all_hbase_opts += " ";
                     all_hbase_opts += hbase_opts;
                 }
-                // set the jmx exporter in HBASE_MASTER_OPTS and BASE_REGIONSERVER_OPTS instead of HBASE_OPTS to prevent a port-conflict
-                // i.e. CLI tools read HBASE_OPTS and may then try to re-start the exporter
-                if !role_name.is_empty() {
-                    let role = HbaseRole::from_str(role_name).unwrap();
-                    match role {
-                        HbaseRole::Master => {
-                            result.insert(
-                                HBASE_MASTER_OPTS.to_string(),
-                                Some(all_hbase_opts.clone()),
-                            );
-                        }
-                        HbaseRole::RegionServer => {
-                            result.insert(BASE_REGIONSERVER_OPTS.to_string(), Some(all_hbase_opts));
-                        }
-                        HbaseRole::RestServer => {
-                            result.insert(
-                                HBASE_MASTER_OPTS.to_string(),
-                                Some(all_hbase_opts.clone()),
-                            );
-                            result.insert(BASE_REGIONSERVER_OPTS.to_string(), Some(all_hbase_opts));
-                        }
-                    }
+                // set the jmx exporter in HBASE_MASTER_OPTS, HBASE_REGIONSERVER_OPTS and HBASE_REST_OPTS instead of HBASE_OPTS
+                // to prevent a port-conflict i.e. CLI tools read HBASE_OPTS and may then try to re-start the exporter
+                if role_name == HbaseRole::Master.to_string() {
+                    result.insert(HBASE_MASTER_OPTS.to_string(), Some(all_hbase_opts));
+                } else if role_name == HbaseRole::RegionServer.to_string() {
+                    result.insert(HBASE_REGIONSERVER_OPTS.to_string(), Some(all_hbase_opts));
+                } else if role_name == HbaseRole::RestServer.to_string() {
+                    result.insert(HBASE_REST_OPTS.to_string(), Some(all_hbase_opts));
                 }
             }
             HBASE_SITE_XML => {

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -14,7 +14,8 @@ pub const HBASE_ENV_SH: &str = "hbase-env.sh";
 pub const HBASE_SITE_XML: &str = "hbase-site.xml";
 
 pub const HBASE_MANAGES_ZK: &str = "HBASE_MANAGES_ZK";
-pub const HBASE_OPTS: &str = "HBASE_OPTS";
+pub const HBASE_MASTER_OPTS: &str = "HBASE_MASTER_OPTS";
+pub const BASE_REGIONSERVER_OPTS: &str = "BASE_REGIONSERVER_OPTS";
 
 pub const HBASE_CLUSTER_DISTRIBUTED: &str = "hbase.cluster.distributed";
 pub const HBASE_ROOTDIR: &str = "hbase.rootdir";
@@ -152,7 +153,10 @@ impl Configuration for HbaseConfig {
                     all_hbase_opts += " ";
                     all_hbase_opts += hbase_opts;
                 }
-                result.insert(HBASE_OPTS.to_string(), Some(all_hbase_opts));
+                // set the jmx exporter in HBASE_MASTER_OPTS and BASE_REGIONSERVER_OPTS instead of HBASE_OPTS to prevent a port-conflict
+                // i.e. CLI tools read HBASE_OPTS and may then try to re-start the exporter
+                result.insert(HBASE_MASTER_OPTS.to_string(), Some(all_hbase_opts.clone()));
+                result.insert(BASE_REGIONSERVER_OPTS.to_string(), Some(all_hbase_opts));
             }
             HBASE_SITE_XML => {
                 result.insert(


### PR DESCRIPTION
# Description

Moved JMX settings to `HBASE_MASTER_OPTS` and `HBASE_MASTER_OPTS`. This can be tested by opening a shell on one of the HBase pods and running e.g.

`./bin/hbase shell`

 and then

```
create 'test', 'cf'
list 'test'
put 'test', 'row1', 'cf:a', 'value1'
put 'test', 'row2', 'cf:b', 'value2'
put 'test', 'row3', 'cf:c', 'value3'
put 'test', 'row4', 'cf:d', 'value4'
scan 'test'
get 'test', 'row1'
disable 'test'
enable 'test'
```

Fixes #166.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
