### PR TITLE
[Merged by Bors] - bugfix: phoenix tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### Added
 
 - Cpu and memory limits are now configurable ([#245]).
+- Fix for Phoenix tests ([#261])
 
 [#245]: https://github.com/stackabletech/hbase-operator/pull/245
+[#261]: https://github.com/stackabletech/hbase-operator/pull/261
 
 ## [0.4.0] - 2022-09-06
 

--- a/rust/operator-binary/src/hbase_controller.rs
+++ b/rust/operator-binary/src/hbase_controller.rs
@@ -555,6 +555,8 @@ fn build_rolegroup_statefulset(
         ]
         .join(" && ")])
         .add_env_var("HBASE_CONF_DIR", CONFIG_DIR_NAME)
+        // required by phoenix (for cases where Kerberos is enabled): see https://issues.apache.org/jira/browse/PHOENIX-2369
+        .add_env_var("HADOOP_CONF_DIR", CONFIG_DIR_NAME)
         .add_volume_mount("hbase-config", HBASE_CONFIG_TMP_DIR)
         .add_volume_mount("hdfs-discovery", HDFS_DISCOVERY_TMP_DIR)
         .add_container_ports(ports)

--- a/tests/templates/kuttl/smoke/02-install-hbase.yaml.j2
+++ b/tests/templates/kuttl/smoke/02-install-hbase.yaml.j2
@@ -12,12 +12,24 @@ spec:
   masters:
     roleGroups:
       default:
+        configOverrides:
+          hbase-site.xml:
+            phoenix.log.saltBuckets: "2"
+            hbase.regionserver.wal.codec: "org.apache.hadoop.hbase.regionserver.wal.IndexedWALEditCodec"
         replicas: 1
   regionServers:
     roleGroups:
       default:
+        configOverrides:
+          hbase-site.xml:
+            phoenix.log.saltBuckets: "2"
+            hbase.regionserver.wal.codec: "org.apache.hadoop.hbase.regionserver.wal.IndexedWALEditCodec"
         replicas: 1
   restServers:
     roleGroups:
       default:
+        configOverrides:
+          hbase-site.xml:
+            phoenix.log.saltBuckets: "2"
+            hbase.regionserver.wal.codec: "org.apache.hadoop.hbase.regionserver.wal.IndexedWALEditCodec"
         replicas: 1


### PR DESCRIPTION
# Description

The default setting (32) for `SALT_BUCKETS` on the Phoenix table` SYSTEM.LOG` is too high and causes regions to get caught in transition. Reduce to a smaller value (currently set to 2 in the test but has been tested up to 8) and set this in the hbase cluster resource. Since we have included the hadoop configuration in `hbase-site.xml` we can point `HADOOP_CONF_DIR` to this, too, as otherwise the wrong location is chosen (by the `sqlline` utility, at least).
`hbase.regionserver.wal.codec` needs to be set to a value to allow phoenix global indices (though this could maybe be a standard setting?)

Jenkins: https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/hbase-operator-it-custom/61/

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] ~CRD change approved (or not applicable)~
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
