### PR TITLE
[Merged by Bors] - Adapted tests & examples to new hdfs crd structure

### DIFF
--- a/docs/modules/hbase/examples/getting_started/hdfs.yaml
+++ b/docs/modules/hbase/examples/getting_started/hdfs.yaml
@@ -7,8 +7,9 @@ spec:
   image:
     productVersion: 3.3.4
     stackableVersion: 0.2.0
-  zookeeperConfigMapName: simple-znode
-  dfsReplication: 3
+  clusterConfig:
+    dfsReplication: 1
+    zookeeperConfigMapName: simple-znode
   nameNodes:
     roleGroups:
       default:

--- a/tests/templates/kuttl/logging/03-install-hdfs.yaml.j2
+++ b/tests/templates/kuttl/logging/03-install-hdfs.yaml.j2
@@ -7,9 +7,10 @@ spec:
   image:
     productVersion: "{{ test_scenario['values']['hdfs-latest'].split('-stackable')[0] }}"
     stackableVersion: "{{ test_scenario['values']['hdfs-latest'].split('-stackable')[1] }}"
-  zookeeperConfigMapName: test-znode
+  clusterConfig:
+    zookeeperConfigMapName: test-znode
 {% if lookup('env', 'VECTOR_AGGREGATOR') %}
-  vectorAggregatorConfigMapName: vector-aggregator-discovery
+    vectorAggregatorConfigMapName: vector-aggregator-discovery
 {% endif %}
   nameNodes:
     config:

--- a/tests/templates/kuttl/orphaned_resources/02-install-hdfs.yaml.j2
+++ b/tests/templates/kuttl/orphaned_resources/02-install-hdfs.yaml.j2
@@ -7,9 +7,10 @@ spec:
   image:
     productVersion: "{{ test_scenario['values']['hdfs-latest'].split('-stackable')[0] }}"
     stackableVersion: "{{ test_scenario['values']['hdfs-latest'].split('-stackable')[1] }}"
-  zookeeperConfigMapName: test-znode
+  clusterConfig:
+    zookeeperConfigMapName: test-znode
 {% if lookup('env', 'VECTOR_AGGREGATOR') %}
-  vectorAggregatorConfigMapName: vector-aggregator-discovery
+    vectorAggregatorConfigMapName: vector-aggregator-discovery
 {% endif %}
   nameNodes:
     config:

--- a/tests/templates/kuttl/resources/02-install-hdfs.yaml.j2
+++ b/tests/templates/kuttl/resources/02-install-hdfs.yaml.j2
@@ -7,9 +7,10 @@ spec:
   image:
     productVersion: "{{ test_scenario['values']['hdfs-latest'].split('-stackable')[0] }}"
     stackableVersion: "{{ test_scenario['values']['hdfs-latest'].split('-stackable')[1] }}"
-  zookeeperConfigMapName: test-znode
+  clusterConfig:
+    zookeeperConfigMapName: test-znode
 {% if lookup('env', 'VECTOR_AGGREGATOR') %}
-  vectorAggregatorConfigMapName: vector-aggregator-discovery
+    vectorAggregatorConfigMapName: vector-aggregator-discovery
 {% endif %}
   nameNodes:
     config:

--- a/tests/templates/kuttl/smoke/02-install-hdfs.yaml.j2
+++ b/tests/templates/kuttl/smoke/02-install-hdfs.yaml.j2
@@ -7,9 +7,10 @@ spec:
   image:
     productVersion: "{{ test_scenario['values']['hdfs'].split('-stackable')[0] }}"
     stackableVersion: "{{ test_scenario['values']['hdfs'].split('-stackable')[1] }}"
-  zookeeperConfigMapName: test-znode
+  clusterConfig:
+    zookeeperConfigMapName: test-znode
 {% if lookup('env', 'VECTOR_AGGREGATOR') %}
-  vectorAggregatorConfigMapName: vector-aggregator-discovery
+    vectorAggregatorConfigMapName: vector-aggregator-discovery
 {% endif %}
   nameNodes:
     config:


### PR DESCRIPTION
# Description

part of https://github.com/stackabletech/hdfs-operator/issues/289

blocked by https://github.com/stackabletech/hdfs-operator/pull/326

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
