### PR TITLE
[Merged by Bors] - Fix missing quoting of env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@
 ### Changed
 
 - Operator-rs: `0.40.2` -> `0.41.0` ([#349]).
-- Use 0.0.0-dev product images for tests and examples ([#351])
-- Use testing-tools 0.2.0 ([#351])
+- Use 0.0.0-dev product images for tests and examples ([#351]).
+- Use testing-tools 0.2.0 ([#351]).
+
+### Fixed
+
+- Fix missing quoting of env variables. This caused problems when env vars (e.g. from envOverrides) contained a whitespace ([#356]).
 
 [#349]: https://github.com/stackabletech/hbase-operator/pull/349
 [#351]: https://github.com/stackabletech/hbase-operator/pull/351
+[#356]: https://github.com/stackabletech/hbase-operator/pull/356
 
 ## [23.4.0] - 2023-04-17
 
@@ -48,7 +53,6 @@
 [#338]: https://github.com/stackabletech/hbase-operator/pull/338
 [#339]: https://github.com/stackabletech/hbase-operator/pull/339
 [#340]: https://github.com/stackabletech/hbase-operator/pull/340
-
 
 ## [23.1.0] - 2023-01-23
 

--- a/rust/operator-binary/src/hbase_controller.rs
+++ b/rust/operator-binary/src/hbase_controller.rs
@@ -856,7 +856,7 @@ where
     T: Iterator<Item = (&'a String, &'a String)>,
 {
     properties
-        .map(|(variable, value)| format!("export {variable}={value}\n"))
+        .map(|(variable, value)| format!("export {variable}=\"{value}\"\n"))
         .collect()
 }
 


### PR DESCRIPTION
This caused problems when env vars (e.g. from envOverrides) contained a whitespace


# Description

*Please add a description here. This will become the commit message of the merge request later.*

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
