### PR TITLE
[Merged by Bors] - run as root group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Operator-rs: `0.40.2` -> `0.41.0` ([#349]).
 - Use 0.0.0-dev product images for tests and examples ([#351]).
 - Use testing-tools 0.2.0 ([#351]).
+- Run as root group ([#359]).
 
 ### Fixed
 
@@ -23,6 +24,7 @@
 [#351]: https://github.com/stackabletech/hbase-operator/pull/351
 [#356]: https://github.com/stackabletech/hbase-operator/pull/356
 [#357]: https://github.com/stackabletech/hbase-operator/pull/357
+[#359]: https://github.com/stackabletech/hbase-operator/pull/359
 
 ## [23.4.0] - 2023-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix missing quoting of env variables. This caused problems when env vars (e.g. from envOverrides) contained a whitespace ([#356]).
 - Fix `hbase.zookeeper.quorum` to not contain the znode path, instead pass it via `zookeeper.znode.parent` ([#357]).
 - Add `hbase.zookeeper.property.clientPort` setting, because hbase sometimes tried to access zookeeper with the (wrong) default port ([#357]).
+- Fix test assert by adding variable quoting ([#359]).
 
 [#349]: https://github.com/stackabletech/hbase-operator/pull/349
 [#350]: https://github.com/stackabletech/hbase-operator/pull/350

--- a/rust/operator-binary/src/hbase_controller.rs
+++ b/rust/operator-binary/src/hbase_controller.rs
@@ -80,6 +80,7 @@ const HBASE_CONFIG_TMP_DIR: &str = "/stackable/tmp/hbase";
 const HBASE_LOG_CONFIG_TMP_DIR: &str = "/stackable/tmp/log_config";
 
 const DOCKER_IMAGE_BASE_NAME: &str = "hbase";
+const HBASE_UID: i64 = 1000;
 
 pub struct Ctx {
     pub client: stackable_operator::client::Client,
@@ -699,8 +700,8 @@ fn build_rolegroup_statefulset(
         .service_account_name(service_account_name(APP_NAME))
         .security_context(
             PodSecurityContextBuilder::new()
-                .run_as_user(1000)
-                .run_as_group(1000)
+                .run_as_user(HBASE_UID)
+                .run_as_group(0)
                 .fs_group(1000)
                 .build(),
         );

--- a/tests/templates/kuttl/resources/04-assert.yaml
+++ b/tests/templates/kuttl/resources/04-assert.yaml
@@ -4,7 +4,7 @@ kind: TestAssert
 timeout: 600
 skipLogOutput: true
 commands:
-  - script: kubectl get cm -n $NAMESPACE test-hbase-master-default -o yaml | grep -- 'HBASE_HEAPSIZE=1638m'
-  - script: kubectl get cm -n $NAMESPACE test-hbase-regionserver-resources-from-role -o yaml | grep -- 'HBASE_HEAPSIZE=819m'
-  - script: kubectl get cm -n $NAMESPACE test-hbase-regionserver-resources-from-role-group -o yaml | grep -- 'HBASE_HEAPSIZE=2457m'
-  - script: kubectl get cm -n $NAMESPACE test-hbase-restserver-default -o yaml | grep -- 'HBASE_HEAPSIZE=1638m'
+  - script: kubectl get cm -n $NAMESPACE test-hbase-master-default -o yaml | grep -- 'HBASE_HEAPSIZE="1638m"'
+  - script: kubectl get cm -n $NAMESPACE test-hbase-regionserver-resources-from-role -o yaml | grep -- 'HBASE_HEAPSIZE="819m"'
+  - script: kubectl get cm -n $NAMESPACE test-hbase-regionserver-resources-from-role-group -o yaml | grep -- 'HBASE_HEAPSIZE="2457m"'
+  - script: kubectl get cm -n $NAMESPACE test-hbase-restserver-default -o yaml | grep -- 'HBASE_HEAPSIZE="1638m"'


### PR DESCRIPTION
# Description

run as root group instead of 1000.

Subset of tests on open shift:

```
--- PASS: kuttl (891.06s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/resources_hbase-latest-2.4.12-stackable0.0.0-dev_hdfs-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev (144.45s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.12-stackable0.0.0-dev_hdfs-3.3.3-stackable0.0.0-dev_zookeeper-3.7.0-stackable0.0.0-dev_listener-class-cluster-internal (221.14s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.12-stackable0.0.0-dev_hdfs-3.2.2-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_listener-class-cluster-internal (228.49s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.12-stackable0.0.0-dev_hdfs-3.2.2-stackable0.0.0-dev_zookeeper-3.6.3-stackable0.0.0-dev_listener-class-cluster-internal (256.22s)
        --- PASS: kuttl/harness/cluster-operation_hbase-latest-2.4.12-stackable0.0.0-dev_hdfs-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev (233.59s)
        --- PASS: kuttl/harness/orphaned_resources_hbase-latest-2.4.12-stackable0.0.0-dev_hdfs-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev (180.18s)
        --- PASS: kuttl/harness/logging_hbase-2.4.12-stackable0.0.0-dev_hdfs-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev (209.19s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.12-stackable0.0.0-dev_hdfs-3.3.3-stackable0.0.0-dev_zookeeper-3.7.0-stackable0.0.0-dev_listener-class-external-unstable (221.23s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.12-stackable0.0.0-dev_hdfs-3.3.3-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_listener-class-external-unstable (203.61s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.12-stackable0.0.0-dev_hdfs-3.2.2-stackable0.0.0-dev_zookeeper-3.7.0-stackable0.0.0-dev_listener-class-cluster-internal (210.76s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.12-stackable0.0.0-dev_hdfs-3.3.3-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_listener-class-cluster-internal (254.30s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.12-stackable0.0.0-dev_hdfs-3.3.3-stackable0.0.0-dev_zookeeper-3.6.3-stackable0.0.0-dev_listener-class-cluster-internal (213.29s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.12-stackable0.0.0-dev_hdfs-3.2.2-stackable0.0.0-dev_zookeeper-3.7.0-stackable0.0.0-dev_listener-class-external-unstable (231.32s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.12-stackable0.0.0-dev_hdfs-3.2.2-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_listener-class-external-unstable (197.41s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.12-stackable0.0.0-dev_hdfs-3.3.3-stackable0.0.0-dev_zookeeper-3.6.3-stackable0.0.0-dev_listener-class-external-unstable (208.35s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.12-stackable0.0.0-dev_hdfs-3.2.2-stackable0.0.0-dev_zookeeper-3.6.3-stackable0.0.0-dev_listener-class-external-unstable (189.55s)
PASS
```


<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
