### PR TITLE
[Merged by Bors] - Add missing crd defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Generate OLM bundle for Release 23.4.0 ([#350]).
+- Missing CRD defaults for `status.conditions` field ([#360]).
 
 ### Changed
 
@@ -26,6 +27,7 @@
 [#356]: https://github.com/stackabletech/hbase-operator/pull/356
 [#357]: https://github.com/stackabletech/hbase-operator/pull/357
 [#359]: https://github.com/stackabletech/hbase-operator/pull/359
+[#360]: https://github.com/stackabletech/hbase-operator/pull/360
 
 ## [23.4.0] - 2023-04-17
 

--- a/deploy/helm/hbase-operator/crds/crds.yaml
+++ b/deploy/helm/hbase-operator/crds/crds.yaml
@@ -3968,6 +3968,7 @@ spec:
               nullable: true
               properties:
                 conditions:
+                  default: []
                   items:
                     properties:
                       lastTransitionTime:
@@ -4009,8 +4010,6 @@ spec:
                       - type
                     type: object
                   type: array
-              required:
-                - conditions
               type: object
           required:
             - spec

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -352,6 +352,7 @@ impl Configuration for HbaseConfigFragment {
 #[derive(Clone, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HbaseClusterStatus {
+    #[serde(default)]
     pub conditions: Vec<ClusterCondition>,
 }
 


### PR DESCRIPTION
# Description

Due to breaking changes in with the `clusterConfig` the CRD replace still works but the operator throws an error:
```
2023-05-12T08:27:57.068053Z ERROR stackable_operator::logging::controller: Failed to reconcile object controller.name="hbasecluster.hbase.stackable.com" error=event queue error error.sources=[failed 
to perform initial object list: Error deserializing response, Error deserializing response, missing field `zookeeperConfigMapName` at line 1 column 5778]
```

This will be gone when applying a new correct CR.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
