### PR TITLE
Add missing crd defaults to 23.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [23.4.1] - 2023-05-17
 
+### Added
+
+- Missing CRD defaults for `status.conditions` field ([#360]).
+
 ### Changed
 
 - Run as root group ([#359]).
@@ -13,6 +17,7 @@
 - Fix test assert by adding variable quoting ([#359]).
 
 [#359]: https://github.com/stackabletech/hbase-operator/pull/359
+[#360]: https://github.com/stackabletech/hbase-operator/pull/360
 
 ## [23.4.0] - 2023-04-17
 
@@ -51,7 +56,6 @@
 [#338]: https://github.com/stackabletech/hbase-operator/pull/338
 [#339]: https://github.com/stackabletech/hbase-operator/pull/339
 [#340]: https://github.com/stackabletech/hbase-operator/pull/340
-
 
 ## [23.1.0] - 2023-01-23
 

--- a/deploy/helm/hbase-operator/crds/crds.yaml
+++ b/deploy/helm/hbase-operator/crds/crds.yaml
@@ -3968,6 +3968,7 @@ spec:
               nullable: true
               properties:
                 conditions:
+                  default: []
                   items:
                     properties:
                       lastTransitionTime:
@@ -4009,8 +4010,6 @@ spec:
                       - type
                     type: object
                   type: array
-              required:
-                - conditions
               type: object
           required:
             - spec

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -353,6 +353,7 @@ impl Configuration for HbaseConfigFragment {
 #[derive(Clone, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HbaseClusterStatus {
+    #[serde(default)]
     pub conditions: Vec<ClusterCondition>,
 }
 


### PR DESCRIPTION
# Description

Add missing crd defaults (#360)

(cherry picked from commit 45f104095fab9e238cd838160198924e12a39d3a)

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
