### PR TITLE
[Merged by Bors] - Set resource limits for operator deployment

### DIFF
--- a/deploy/helm/hbase-operator/values.yaml
+++ b/deploy/helm/hbase-operator/values.yaml
@@ -30,17 +30,13 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
For https://github.com/stackabletech/issues/issues/368 we need to set resource limits on all resources deployed by our helm charts.