### PR TITLE
[Merged by Bors] - nightly test suite

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -85,4 +85,3 @@ suites:
             expr: last
           - name: hdfs
             expr: last
- 

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -57,13 +57,21 @@ tests:
       - hdfs-latest
       - zookeeper-latest
 suites:
-  - name: latest
+  - name: nightly
+    patch:
+      - dimensions:
+          - name: hbase
+            expr: last
+          - name: zookeeper
+            expr: last
+          - name: hdfs
+            expr: last
+  - name: smoke-latest
+    select:
+      - smoke
     patch:
       - dimensions:
           - expr: last
-  - name: smoke
-    select:
-      - smoke
   - name: openshift
     patch:
       - dimensions:
@@ -71,3 +79,10 @@ suites:
       - dimensions:
           - name: openshift
             expr: "true"
+          - name: hbase
+            expr: last
+          - name: zookeeper
+            expr: last
+          - name: hdfs
+            expr: last
+ 


### PR DESCRIPTION
Part of https://github.com/stackabletech/ci/issues/62

```
(stackable) ➜  hbase-operator git:(feat/nightly-suite) ✗ beku -s nightly     
INFO:root:Expanding test case id [smoke_hbase-2.4.12-stackable0.0.0-dev_hdfs-3.3.3-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_listener-class-cluster-internal]
INFO:root:Expanding test case id [smoke_hbase-2.4.12-stackable0.0.0-dev_hdfs-3.3.3-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_listener-class-external-unstable]
INFO:root:Expanding test case id [orphaned_resources_hbase-latest-2.4.12-stackable0.0.0-dev_hdfs-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [resources_hbase-latest-2.4.12-stackable0.0.0-dev_hdfs-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [logging_hbase-2.4.12-stackable0.0.0-dev_hdfs-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [cluster-operation_hbase-latest-2.4.12-stackable0.0.0-dev_hdfs-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
```
```
(stackable) ➜  hbase-operator git:(feat/nightly-suite) ✗ beku -s smoke-latest
INFO:root:Expanding test case id [smoke_hbase-2.4.12-stackable0.0.0-dev_hdfs-3.3.3-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_listener-class-external-unstable]
```
```
(stackable) ➜  hbase-operator git:(feat/nightly-suite) ✗ beku -s openshift   
INFO:root:Expanding test case id [smoke_hbase-2.4.12-stackable0.0.0-dev_hdfs-3.3.3-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_listener-class-external-unstable]
INFO:root:Expanding test case id [orphaned_resources_hbase-latest-2.4.12-stackable0.0.0-dev_hdfs-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [resources_hbase-latest-2.4.12-stackable0.0.0-dev_hdfs-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [logging_hbase-2.4.12-stackable0.0.0-dev_hdfs-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [cluster-operation_hbase-latest-2.4.12-stackable0.0.0-dev_hdfs-latest-3.3.4-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
```