### PR TITLE
Disable reverse DNS lookup for RegionServers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 ### Fixed
 
 - Fix Zookeeper hbase.rootdir when users point to discovery ConfigMap of ZookeeperCluster rather than ZNode. Print a warning in that case ([#394]).
+- Default `hbase.unsafe.regionserver.hostname.disable.master.reversedns` to
+  `true`, to ensure the names of RegionServers are resolved to their hostnames
+  instead of IP addresses ([#418]).
 
 ### Removed
 
@@ -30,6 +33,7 @@
 [#399]: https://github.com/stackabletech/hbase-operator/pull/399
 [#402]: https://github.com/stackabletech/hbase-operator/pull/402
 [#403]: https://github.com/stackabletech/hbase-operator/pull/403
+[#418]: https://github.com/stackabletech/hbase-operator/pull/418
 
 ## [23.7.0] - 2023-07-14
 

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -44,6 +44,8 @@ pub const HBASE_REST_OPTS: &str = "HBASE_REST_OPTS";
 
 pub const HBASE_CLUSTER_DISTRIBUTED: &str = "hbase.cluster.distributed";
 pub const HBASE_ROOTDIR: &str = "hbase.rootdir";
+pub const HBASE_UNSAFE_REGIONSERVER_HOSTNAME_DISABLE_MASTER_REVERSEDNS: &str =
+    "hbase.unsafe.regionserver.hostname.disable.master.reversedns";
 pub const HBASE_HEAPSIZE: &str = "HBASE_HEAPSIZE";
 pub const HBASE_ROOT_DIR_DEFAULT: &str = "/hbase";
 
@@ -375,6 +377,10 @@ impl Configuration for HbaseConfigFragment {
             HBASE_SITE_XML => {
                 result.insert(
                     HBASE_CLUSTER_DISTRIBUTED.to_string(),
+                    Some("true".to_string()),
+                );
+                result.insert(
+                    HBASE_UNSAFE_REGIONSERVER_HOSTNAME_DISABLE_MASTER_REVERSEDNS.to_string(),
                     Some("true".to_string()),
                 );
                 result.insert(


### PR DESCRIPTION
# Description

Default `hbase.unsafe.regionserver.hostname.disable.master.reversedns` to `true`, to ensure the names of RegionServers are resolved to their hostnames instead of IP addresses.

If desired, this option can be reset to `false` in `configOverrides` at the rolegroup level, but not at the role level (see stackabletech/operator-rs#339).

Closes #405 

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
