### PR TITLE
fix: kerberos tests to run on openshift

### DIFF
--- a/tests/templates/kuttl/kerberos/00-rbac.yaml.j2
+++ b/tests/templates/kuttl/kerberos/00-rbac.yaml.j2
@@ -1,0 +1,29 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-role
+rules:
+{% if test_scenario['values']['openshift'] == "true" %}
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    resourceNames: ["privileged"]
+    verbs: ["use"]
+{% endif %}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-sa
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-rb
+subjects:
+  - kind: ServiceAccount
+    name: test-sa
+roleRef:
+  kind: Role
+  name: test-role
+  apiGroup: rbac.authorization.k8s.io

--- a/tests/templates/kuttl/kerberos/01-install-krb5-kdc.yaml.j2
+++ b/tests/templates/kuttl/kerberos/01-install-krb5-kdc.yaml.j2
@@ -12,6 +12,7 @@ spec:
       labels:
         app: krb5-kdc
     spec:
+      serviceAccountName: test-sa
       initContainers:
         - name: init
           image: docker.stackable.tech/stackable/krb5:1.18.2-stackable0.0.0-dev
@@ -47,6 +48,11 @@ spec:
               name: config
             - mountPath: /var/kerberos/krb5kdc
               name: data
+# Root permissions required on Openshift to access internal ports
+{% if test_scenario['values']['openshift'] == "true" %}
+          securityContext:
+            runAsUser: 0
+{% endif %}
         - name: kadmind
           image: docker.stackable.tech/stackable/krb5:1.18.2-stackable0.0.0-dev
           args:
@@ -60,6 +66,11 @@ spec:
               name: config
             - mountPath: /var/kerberos/krb5kdc
               name: data
+# Root permissions required on Openshift to access internal ports
+{% if test_scenario['values']['openshift'] == "true" %}
+          securityContext:
+            runAsUser: 0
+{% endif %}
         - name: client
           image: docker.stackable.tech/stackable/krb5:1.18.2-stackable0.0.0-dev
           tty: true

--- a/tests/templates/kuttl/kerberos/01-install-krb5-kdc.yaml.j2
+++ b/tests/templates/kuttl/kerberos/01-install-krb5-kdc.yaml.j2
@@ -66,7 +66,7 @@ spec:
               name: config
             - mountPath: /var/kerberos/krb5kdc
               name: data
-# Root permissions required on Openshift to access internal ports
+# Root permissions required on Openshift to bind to privileged port numbers
 {% if test_scenario['values']['openshift'] == "true" %}
           securityContext:
             runAsUser: 0

--- a/tests/templates/kuttl/kerberos/01-install-krb5-kdc.yaml.j2
+++ b/tests/templates/kuttl/kerberos/01-install-krb5-kdc.yaml.j2
@@ -48,7 +48,7 @@ spec:
               name: config
             - mountPath: /var/kerberos/krb5kdc
               name: data
-# Root permissions required on Openshift to access internal ports
+# Root permissions required on Openshift to bind to privileged port numbers
 {% if test_scenario['values']['openshift'] == "true" %}
           securityContext:
             runAsUser: 0

--- a/tests/templates/kuttl/kerberos/20-access-hdfs.yaml.j2
+++ b/tests/templates/kuttl/kerberos/20-access-hdfs.yaml.j2
@@ -12,6 +12,7 @@ commands:
       spec:
         template:
           spec:
+            serviceAccountName: test-sa
             containers:
               - name: access-hdfs
                 image: docker.stackable.tech/stackable/hadoop:{{ test_scenario['values']['hdfs-latest'] }}-stackable0.0.0-dev

--- a/tests/templates/kuttl/kerberos/41-access-hbase.yaml.j2
+++ b/tests/templates/kuttl/kerberos/41-access-hbase.yaml.j2
@@ -12,6 +12,7 @@ commands:
       spec:
         template:
           spec:
+            serviceAccountName: test-sa
             containers:
               - name: access-hbase
                 image: docker.stackable.tech/stackable/hbase:{{ test_scenario['values']['hbase'] }}-stackable0.0.0-dev

--- a/tests/templates/kuttl/kerberos/42-test-rest-server.yaml
+++ b/tests/templates/kuttl/kerberos/42-test-rest-server.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   template:
     spec:
+      serviceAccountName: test-sa
       containers:
         - name: test-rest-server
           image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable0.0.0-dev

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -52,6 +52,7 @@ tests:
       - listener-class
       - kerberos-realm
       - kerberos-backend
+      - openshift
   - name: orphaned_resources
     dimensions:
       - hbase-latest


### PR DESCRIPTION
# Description

fix: kerberos tests to run on openshift

```
--- PASS: kuttl (1903.04s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.17_hdfs-3.3.6_zookeeper-3.8.3_listener-class-external-unstable (379.60s)
        --- PASS: kuttl/harness/logging_hbase-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.8.3 (210.53s)
        --- PASS: kuttl/harness/cluster-operation_hbase-latest-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.8.3 (239.90s)
        --- PASS: kuttl/harness/orphaned_resources_hbase-latest-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.8.3 (199.59s)
        --- PASS: kuttl/harness/resources_hbase-latest-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.8.3 (184.67s)
        --- PASS: kuttl/harness/kerberos_hbase-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.8.3_listener-class-external-unstable_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-true (470.92s)
        --- PASS: kuttl/harness/profiling_hbase-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.8.3_openshift-true (209.15s)

```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] Code contains useful logging statements
- [x] (Integration-)Test cases added
- [x] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
