### PR TITLE
tests: added namespace patch for openshift tests

### DIFF
--- a/tests/release.yaml
+++ b/tests/release.yaml
@@ -1,7 +1,7 @@
 # Contains all operators required to run the test suite.
 ---
 releases:
-  # Do not change the name of the release as it's referenced from run_tests.sh
+  # Do not change the name of the release as it's referenced from run-tests
   tests:
     releaseDate: 1970-01-01
     description: Integration test

--- a/tests/templates/kuttl/cluster-operation/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/cluster-operation/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/kerberos/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/kerberos/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/logging/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/logging/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/orphaned_resources/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/orphaned_resources/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/profiling/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/profiling/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/resources/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/resources/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/smoke/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/smoke/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -44,6 +44,7 @@ tests:
       - hdfs
       - zookeeper
       - listener-class
+      - openshift
   - name: kerberos
     dimensions:
       - hbase
@@ -58,21 +59,25 @@ tests:
       - hbase-latest
       - hdfs-latest
       - zookeeper-latest
+      - openshift
   - name: resources
     dimensions:
       - hbase-latest
       - hdfs-latest
       - zookeeper-latest
+      - openshift
   - name: logging
     dimensions:
       - hbase
       - hdfs-latest
       - zookeeper-latest
+      - openshift
   - name: cluster-operation
     dimensions:
       - hbase-latest
       - hdfs-latest
       - zookeeper-latest
+      - openshift
   - name: profiling
     dimensions:
       - hbase


### PR DESCRIPTION
# Description

Part of stackabletech/issues#566.

OKD:

```
--- PASS: kuttl (939.31s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/cluster-operation_hbase-latest-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.9.1_openshift-true (279.22s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.17_hdfs-3.3.6_zookeeper-3.8.3_listener-class-external-unstable_openshift-true (309.81s)
        --- PASS: kuttl/harness/orphaned_resources_hbase-latest-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.9.1_openshift-true (184.70s)
        --- PASS: kuttl/harness/profiling_hbase-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.9.1_openshift-true (190.50s)
        --- PASS: kuttl/harness/resources_hbase-latest-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.9.1_openshift-true (191.40s)
        --- PASS: kuttl/harness/logging_hbase-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.9.1_openshift-true (233.72s)
        --- PASS: kuttl/harness/kerberos_hbase-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.9.1_listener-class-external-unstable_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-true (429.44s)
```

Azure:
```
--- PASS: kuttl (1214.33s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/resources_hbase-latest-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.9.1_openshift-false (213.96s)
        --- PASS: kuttl/harness/profiling_hbase-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.9.1_openshift-false (226.53s)
        --- PASS: kuttl/harness/kerberos_hbase-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.9.1_listener-class-cluster-internal_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (434.59s)
        --- PASS: kuttl/harness/kerberos_hbase-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.9.1_listener-class-external-unstable_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (429.87s)
        --- PASS: kuttl/harness/logging_hbase-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.9.1_openshift-false (195.77s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.17_hdfs-3.3.6_zookeeper-3.8.3_listener-class-cluster-internal_openshift-false (212.19s)
        --- PASS: kuttl/harness/cluster-operation_hbase-latest-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.9.1_openshift-false (174.47s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.17_hdfs-3.3.6_zookeeper-3.8.3_listener-class-external-unstable_openshift-false (248.07s)
        --- PASS: kuttl/harness/orphaned_resources_hbase-latest-2.4.17_hdfs-latest-3.3.6_zookeeper-latest-3.9.1_openshift-false (169.13s)
```


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
