### PR TITLE
Update the krb5 image in the integration tests

### DIFF
--- a/tests/templates/kuttl/kerberos/01-install-krb5-kdc.yaml.j2
+++ b/tests/templates/kuttl/kerberos/01-install-krb5-kdc.yaml.j2
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: test-sa
       initContainers:
         - name: init
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
           args:
             - sh
             - -euo
@@ -36,7 +36,7 @@ spec:
               name: data
       containers:
         - name: kdc
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
           args:
             - krb5kdc
             - -n
@@ -54,7 +54,7 @@ spec:
             runAsUser: 0
 {% endif %}
         - name: kadmind
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
           args:
             - kadmind
             - -nofork
@@ -72,7 +72,7 @@ spec:
             runAsUser: 0
 {% endif %}
         - name: client
-          image: docker.stackable.tech/stackable/krb5:1.18.2-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
           tty: true
           stdin: true
           env:

--- a/tests/templates/kuttl/kerberos/01-install-krb5-kdc.yaml.j2
+++ b/tests/templates/kuttl/kerberos/01-install-krb5-kdc.yaml.j2
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: test-sa
       initContainers:
         - name: init
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - sh
             - -euo
@@ -36,7 +36,7 @@ spec:
               name: data
       containers:
         - name: kdc
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - krb5kdc
             - -n
@@ -54,7 +54,7 @@ spec:
             runAsUser: 0
 {% endif %}
         - name: kadmind
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - kadmind
             - -nofork
@@ -72,7 +72,7 @@ spec:
             runAsUser: 0
 {% endif %}
         - name: client
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5-latest'] }}-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           tty: true
           stdin: true
           env:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -19,6 +19,9 @@ dimensions:
   - name: zookeeper-latest
     values:
       - 3.9.1
+  - name: krb5-latest
+    values:
+      - 1.21.1
   # Used for zookeeper, hdfs and hbase
   - name: listener-class
     values:
@@ -50,6 +53,7 @@ tests:
       - hbase
       - hdfs-latest
       - zookeeper-latest
+      - krb5-latest
       - listener-class
       - kerberos-realm
       - kerberos-backend

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -19,7 +19,7 @@ dimensions:
   - name: zookeeper-latest
     values:
       - 3.9.1
-  - name: krb5-latest
+  - name: krb5
     values:
       - 1.21.1
   # Used for zookeeper, hdfs and hbase
@@ -53,7 +53,7 @@ tests:
       - hbase
       - hdfs-latest
       - zookeeper-latest
-      - krb5-latest
+      - krb5
       - listener-class
       - kerberos-realm
       - kerberos-backend


### PR DESCRIPTION
# Description

Update the krb5 image in the integration tests

The krb5 version was upgraded from 1.18.2 to 1.21.1 in stackabletech/docker-images#627. As the image with version 1.18.2 is not built anymore, it must be replaced in all integration tests.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
