### PR TITLE
Update the ZooKeeper image in the integration tests

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -15,7 +15,7 @@ dimensions:
       - 3.3.6
   - name: zookeeper
     values:
-      - 3.8.3
+      - 3.8.4
   - name: zookeeper-latest
     values:
       - 3.9.2

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -18,7 +18,7 @@ dimensions:
       - 3.8.3
   - name: zookeeper-latest
     values:
-      - 3.9.1
+      - 3.9.2
   - name: krb5
     values:
       - 1.21.1


### PR DESCRIPTION
# Description

Update the ZooKeeper image in the integration tests

The ZooKeeper version was upgraded from 3.9.1 to 3.9.2 in stackabletech/docker-images#592. As the image with version 3.9.1 is not built anymore, it must be replaced in all integration tests.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
