### PR TITLE
Use an emptyDir instead of a persistentVolumeClaim for MinIO in the integration tests

### DIFF
--- a/tests/templates/kuttl/snapshot-export/10-install-minio.yaml.j2
+++ b/tests/templates/kuttl/snapshot-export/10-install-minio.yaml.j2
@@ -4,7 +4,7 @@ kind: TestStep
 commands:
   - script: >-
       helm install minio oci://registry-1.docker.io/bitnamicharts/minio
-      --version 14.1.7
+      --version 14.6.9
       --values 10_helm-bitnami-minio-values.yaml
       --namespace $NAMESPACE
     timeout: 240

--- a/tests/templates/kuttl/snapshot-export/10_helm-bitnami-minio-values.yaml.j2
+++ b/tests/templates/kuttl/snapshot-export/10_helm-bitnami-minio-values.yaml.j2
@@ -1,5 +1,6 @@
 ---
 persistence:
+  enabled: false # "false" means, that an emptyDir is used instead of a persistentVolumeClaim
   size: 64Mi
 
 provisioning:


### PR DESCRIPTION
# Description

The integration tests fail on an IONOS cluster because MinIO cannot be deployed due to the following error:

> failed to provision volume with StorageClass "ionos-enterprise-hdd": rpc error: code = OutOfRange desc = requested size 67108864 must be between 1073741824 and 4398046511104 bytes

A PersistentVolumeClaim with 64 MiB is created which is not supported. Instead of requesting 1 GiB, an emptyDir is now used instead.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
