### PR TITLE
Fix the Omid test

### DIFF
--- a/tests/templates/kuttl/omid/40-install-omid.yaml.j2
+++ b/tests/templates/kuttl/omid/40-install-omid.yaml.j2
@@ -46,7 +46,7 @@ spec:
 {% if test_scenario['values']['omid'].find(",") > 0 %}
           image: "{{ test_scenario['values']['omid'].split(',')[1] }}"
 {% else %}
-          image: docker.stackable.tech/stackable/omid:"{{ test_scenario['values']['omid'] }}"-stackable0.0.0-dev
+          image: docker.stackable.tech/stackable/omid:{{ test_scenario['values']['omid'] }}-stackable0.0.0-dev
 {% endif %}
           imagePullPolicy: IfNotPresent
           command:


### PR DESCRIPTION
# Description

Fix the Omid test

The Omid test failed in the test step `40-install-omid` due to an invalid image name:

> Failed to apply default image tag "docker.stackable.tech/stackable/omid:\\"1.1.0\\"-stackable0.0.0-dev": couldn't parse image name "docker.stackable.tech/stackable/omid:\\"1.1.0\\"-stackable0.0.0-dev": invalid reference format

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
