### PR TITLE
chore: Use LTS ZooKeeper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [24.7.0] - 2024-07-24
+
 ### Added
 
 - Added support for HBase 2.6.0 with the following changes ([#506]):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,7 +2082,7 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stackable-hbase-crd"
-version = "0.0.0-dev"
+version = "24.7.0"
 dependencies = [
  "rstest",
  "serde",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-hbase-operator"
-version = "0.0.0-dev"
+version = "24.7.0"
 dependencies = [
  "anyhow",
  "built",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -6435,7 +6435,7 @@ rec {
       };
       "stackable-hbase-crd" = rec {
         crateName = "stackable-hbase-crd";
-        version = "0.0.0-dev";
+        version = "24.7.0";
         edition = "2021";
         # We can't filter paths with references in Nix 2.4
         # See https://github.com/NixOS/nix/issues/5410
@@ -6488,7 +6488,7 @@ rec {
       };
       "stackable-hbase-operator" = rec {
         crateName = "stackable-hbase-operator";
-        version = "0.0.0-dev";
+        version = "24.7.0";
         edition = "2021";
         crateBin = [
           {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["rust/crd", "rust/operator-binary"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.0-dev"
+version = "24.7.0"
 authors = ["Stackable GmbH <info@stackable.tech>"]
 license = "OSL-3.0"
 edition = "2021"

--- a/deploy/helm/hbase-operator/Chart.yaml
+++ b/deploy/helm/hbase-operator/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: hbase-operator
-version: "0.0.0-dev"
-appVersion: "0.0.0-dev"
+version: "24.7.0"
+appVersion: "24.7.0"
 description: The Stackable Operator for Apache HBase
 home: https://github.com/stackabletech/hbase-operator
 maintainers:

--- a/deploy/helm/hbase-operator/crds/crds.yaml
+++ b/deploy/helm/hbase-operator/crds/crds.yaml
@@ -24,7 +24,7 @@ spec:
           properties:
             spec:
               description: |-
-                An HBase cluster stacklet. This resource is managed by the Stackable operator for Apache HBase. Find more information on how to use it and the resources that the operator generates in the [operator documentation](https://docs.stackable.tech/home/nightly/hbase/).
+                An HBase cluster stacklet. This resource is managed by the Stackable operator for Apache HBase. Find more information on how to use it and the resources that the operator generates in the [operator documentation](https://docs.stackable.tech/home/24.7/hbase/).
 
                 The CRD contains three roles: `masters`, `regionServers` and `restServers`.
               properties:
@@ -32,7 +32,7 @@ spec:
                   description: Configuration that applies to all roles and role groups. This includes settings for logging, ZooKeeper and HDFS connection, among other things.
                   properties:
                     authentication:
-                      description: Settings related to user [authentication](https://docs.stackable.tech/home/nightly/usage-guide/security).
+                      description: Settings related to user [authentication](https://docs.stackable.tech/home/24.7/usage-guide/security).
                       nullable: true
                       properties:
                         kerberos:
@@ -55,10 +55,10 @@ spec:
                       nullable: true
                       properties:
                         opa:
-                          description: Configure the OPA stacklet [discovery ConfigMap](https://docs.stackable.tech/home/nightly/concepts/service_discovery) and the name of the Rego package containing your authorization rules. Consult the [OPA authorization documentation](https://docs.stackable.tech/home/nightly/concepts/opa) to learn how to deploy Rego authorization rules with OPA.
+                          description: Configure the OPA stacklet [discovery ConfigMap](https://docs.stackable.tech/home/24.7/concepts/service_discovery) and the name of the Rego package containing your authorization rules. Consult the [OPA authorization documentation](https://docs.stackable.tech/home/24.7/concepts/opa) to learn how to deploy Rego authorization rules with OPA.
                           properties:
                             configMapName:
-                              description: The [discovery ConfigMap](https://docs.stackable.tech/home/nightly/concepts/service_discovery) for the OPA stacklet that should be used for authorization requests.
+                              description: The [discovery ConfigMap](https://docs.stackable.tech/home/24.7/concepts/service_discovery) for the OPA stacklet that should be used for authorization requests.
                               type: string
                             package:
                               description: The name of the Rego package containing the Rego rules for the product.
@@ -71,7 +71,7 @@ spec:
                         - opa
                       type: object
                     hdfsConfigMapName:
-                      description: Name of the [discovery ConfigMap](https://docs.stackable.tech/home/nightly/concepts/service_discovery) for an HDFS cluster.
+                      description: Name of the [discovery ConfigMap](https://docs.stackable.tech/home/24.7/concepts/service_discovery) for an HDFS cluster.
                       type: string
                     listenerClass:
                       default: cluster-internal
@@ -82,17 +82,17 @@ spec:
 
                         * external-unstable: Use a NodePort service
 
-                        This is a temporary solution with the goal to keep yaml manifests forward compatible. In the future, this setting will control which [ListenerClass](https://docs.stackable.tech/home/nightly/listener-operator/listenerclass.html) will be used to expose the service, and ListenerClass names will stay the same, allowing for a non-breaking change.
+                        This is a temporary solution with the goal to keep yaml manifests forward compatible. In the future, this setting will control which [ListenerClass](https://docs.stackable.tech/home/24.7/listener-operator/listenerclass.html) will be used to expose the service, and ListenerClass names will stay the same, allowing for a non-breaking change.
                       enum:
                         - cluster-internal
                         - external-unstable
                       type: string
                     vectorAggregatorConfigMapName:
-                      description: Name of the Vector aggregator [discovery ConfigMap](https://docs.stackable.tech/home/nightly/concepts/service_discovery). It must contain the key `ADDRESS` with the address of the Vector aggregator. Follow the [logging tutorial](https://docs.stackable.tech/home/nightly/tutorials/logging-vector-aggregator) to learn how to configure log aggregation with Vector.
+                      description: Name of the Vector aggregator [discovery ConfigMap](https://docs.stackable.tech/home/24.7/concepts/service_discovery). It must contain the key `ADDRESS` with the address of the Vector aggregator. Follow the [logging tutorial](https://docs.stackable.tech/home/24.7/tutorials/logging-vector-aggregator) to learn how to configure log aggregation with Vector.
                       nullable: true
                       type: string
                     zookeeperConfigMapName:
-                      description: Name of the [discovery ConfigMap](https://docs.stackable.tech/home/nightly/concepts/service_discovery) for a ZooKeeper cluster.
+                      description: Name of the [discovery ConfigMap](https://docs.stackable.tech/home/24.7/concepts/service_discovery) for a ZooKeeper cluster.
                       type: string
                   required:
                     - hdfsConfigMapName
@@ -102,7 +102,7 @@ spec:
                   default:
                     reconciliationPaused: false
                     stopped: false
-                  description: '[Cluster operations](https://docs.stackable.tech/home/nightly/concepts/operations/cluster_operations) properties, allow stopping the product instance as well as pausing reconciliation.'
+                  description: '[Cluster operations](https://docs.stackable.tech/home/24.7/concepts/operations/cluster_operations) properties, allow stopping the product instance as well as pausing reconciliation.'
                   properties:
                     reconciliationPaused:
                       default: false
@@ -123,7 +123,7 @@ spec:
                   description: |-
                     Specify which image to use, the easiest way is to only configure the `productVersion`. You can also configure a custom image registry to pull from, as well as completely custom images.
 
-                    Consult the [Product image selection documentation](https://docs.stackable.tech/home/nightly/concepts/product_image_selection) for details.
+                    Consult the [Product image selection documentation](https://docs.stackable.tech/home/24.7/concepts/product_image_selection) for details.
                   properties:
                     custom:
                       description: Overwrite the docker image. Specify the full docker image name, e.g. `docker.stackable.tech/stackable/superset:1.4.1-stackable2.1.0`
@@ -177,7 +177,7 @@ spec:
                             nodeSelector: null
                             podAffinity: null
                             podAntiAffinity: null
-                          description: These configuration settings control [Pod placement](https://docs.stackable.tech/home/nightly/concepts/operations/pod_placement).
+                          description: These configuration settings control [Pod placement](https://docs.stackable.tech/home/24.7/concepts/operations/pod_placement).
                           properties:
                             nodeAffinity:
                               description: Node affinity is a group of node affinity scheduling rules.
@@ -699,7 +699,7 @@ spec:
                           default:
                             containers: {}
                             enableVectorAgent: null
-                          description: Logging configuration, learn more in the [logging concept documentation](https://docs.stackable.tech/home/nightly/concepts/logging).
+                          description: Logging configuration, learn more in the [logging concept documentation](https://docs.stackable.tech/home/24.7/concepts/logging).
                           properties:
                             containers:
                               additionalProperties:
@@ -824,17 +824,17 @@ spec:
                           type: string
                         type: object
                       default: {}
-                      description: The `configOverrides` can be used to configure properties in product config files that are not exposed in the CRD. Read the [config overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#config-overrides) and consult the operator specific usage guide documentation for details on the available config files and settings for the specific product.
+                      description: The `configOverrides` can be used to configure properties in product config files that are not exposed in the CRD. Read the [config overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#config-overrides) and consult the operator specific usage guide documentation for details on the available config files and settings for the specific product.
                       type: object
                     envOverrides:
                       additionalProperties:
                         type: string
                       default: {}
-                      description: '`envOverrides` configure environment variables to be set in the Pods. It is a map from strings to strings - environment variables and the value to set. Read the [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides) for more information and consult the operator specific usage guide to find out about the product specific environment variables that are available.'
+                      description: '`envOverrides` configure environment variables to be set in the Pods. It is a map from strings to strings - environment variables and the value to set. Read the [environment variable overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#env-overrides) for more information and consult the operator specific usage guide to find out about the product specific environment variables that are available.'
                       type: object
                     podOverrides:
                       default: {}
-                      description: In the `podOverrides` property you can define a [PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core) to override any property that can be set on a Kubernetes Pod. Read the [Pod overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#pod-overrides) for more information.
+                      description: In the `podOverrides` property you can define a [PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core) to override any property that can be set on a Kubernetes Pod. Read the [Pod overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#pod-overrides) for more information.
                       properties:
                         metadata:
                           properties:
@@ -3744,7 +3744,7 @@ spec:
 
                             1. If PodDisruptionBudgets are created by the operator 2. The allowed number of Pods to be unavailable (`maxUnavailable`)
 
-                            Learn more in the [allowed Pod disruptions documentation](https://docs.stackable.tech/home/nightly/concepts/operations/pod_disruptions).
+                            Learn more in the [allowed Pod disruptions documentation](https://docs.stackable.tech/home/24.7/concepts/operations/pod_disruptions).
                           properties:
                             enabled:
                               default: true
@@ -3775,7 +3775,7 @@ spec:
                                   nodeSelector: null
                                   podAffinity: null
                                   podAntiAffinity: null
-                                description: These configuration settings control [Pod placement](https://docs.stackable.tech/home/nightly/concepts/operations/pod_placement).
+                                description: These configuration settings control [Pod placement](https://docs.stackable.tech/home/24.7/concepts/operations/pod_placement).
                                 properties:
                                   nodeAffinity:
                                     description: Node affinity is a group of node affinity scheduling rules.
@@ -4297,7 +4297,7 @@ spec:
                                 default:
                                   containers: {}
                                   enableVectorAgent: null
-                                description: Logging configuration, learn more in the [logging concept documentation](https://docs.stackable.tech/home/nightly/concepts/logging).
+                                description: Logging configuration, learn more in the [logging concept documentation](https://docs.stackable.tech/home/24.7/concepts/logging).
                                 properties:
                                   containers:
                                     additionalProperties:
@@ -4422,17 +4422,17 @@ spec:
                                 type: string
                               type: object
                             default: {}
-                            description: The `configOverrides` can be used to configure properties in product config files that are not exposed in the CRD. Read the [config overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#config-overrides) and consult the operator specific usage guide documentation for details on the available config files and settings for the specific product.
+                            description: The `configOverrides` can be used to configure properties in product config files that are not exposed in the CRD. Read the [config overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#config-overrides) and consult the operator specific usage guide documentation for details on the available config files and settings for the specific product.
                             type: object
                           envOverrides:
                             additionalProperties:
                               type: string
                             default: {}
-                            description: '`envOverrides` configure environment variables to be set in the Pods. It is a map from strings to strings - environment variables and the value to set. Read the [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides) for more information and consult the operator specific usage guide to find out about the product specific environment variables that are available.'
+                            description: '`envOverrides` configure environment variables to be set in the Pods. It is a map from strings to strings - environment variables and the value to set. Read the [environment variable overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#env-overrides) for more information and consult the operator specific usage guide to find out about the product specific environment variables that are available.'
                             type: object
                           podOverrides:
                             default: {}
-                            description: In the `podOverrides` property you can define a [PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core) to override any property that can be set on a Kubernetes Pod. Read the [Pod overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#pod-overrides) for more information.
+                            description: In the `podOverrides` property you can define a [PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core) to override any property that can be set on a Kubernetes Pod. Read the [Pod overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#pod-overrides) for more information.
                             properties:
                               metadata:
                                 properties:
@@ -7354,7 +7354,7 @@ spec:
                             nodeSelector: null
                             podAffinity: null
                             podAntiAffinity: null
-                          description: These configuration settings control [Pod placement](https://docs.stackable.tech/home/nightly/concepts/operations/pod_placement).
+                          description: These configuration settings control [Pod placement](https://docs.stackable.tech/home/24.7/concepts/operations/pod_placement).
                           properties:
                             nodeAffinity:
                               description: Node affinity is a group of node affinity scheduling rules.
@@ -7876,7 +7876,7 @@ spec:
                           default:
                             containers: {}
                             enableVectorAgent: null
-                          description: Logging configuration, learn more in the [logging concept documentation](https://docs.stackable.tech/home/nightly/concepts/logging).
+                          description: Logging configuration, learn more in the [logging concept documentation](https://docs.stackable.tech/home/24.7/concepts/logging).
                           properties:
                             containers:
                               additionalProperties:
@@ -8001,17 +8001,17 @@ spec:
                           type: string
                         type: object
                       default: {}
-                      description: The `configOverrides` can be used to configure properties in product config files that are not exposed in the CRD. Read the [config overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#config-overrides) and consult the operator specific usage guide documentation for details on the available config files and settings for the specific product.
+                      description: The `configOverrides` can be used to configure properties in product config files that are not exposed in the CRD. Read the [config overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#config-overrides) and consult the operator specific usage guide documentation for details on the available config files and settings for the specific product.
                       type: object
                     envOverrides:
                       additionalProperties:
                         type: string
                       default: {}
-                      description: '`envOverrides` configure environment variables to be set in the Pods. It is a map from strings to strings - environment variables and the value to set. Read the [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides) for more information and consult the operator specific usage guide to find out about the product specific environment variables that are available.'
+                      description: '`envOverrides` configure environment variables to be set in the Pods. It is a map from strings to strings - environment variables and the value to set. Read the [environment variable overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#env-overrides) for more information and consult the operator specific usage guide to find out about the product specific environment variables that are available.'
                       type: object
                     podOverrides:
                       default: {}
-                      description: In the `podOverrides` property you can define a [PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core) to override any property that can be set on a Kubernetes Pod. Read the [Pod overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#pod-overrides) for more information.
+                      description: In the `podOverrides` property you can define a [PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core) to override any property that can be set on a Kubernetes Pod. Read the [Pod overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#pod-overrides) for more information.
                       properties:
                         metadata:
                           properties:
@@ -10921,7 +10921,7 @@ spec:
 
                             1. If PodDisruptionBudgets are created by the operator 2. The allowed number of Pods to be unavailable (`maxUnavailable`)
 
-                            Learn more in the [allowed Pod disruptions documentation](https://docs.stackable.tech/home/nightly/concepts/operations/pod_disruptions).
+                            Learn more in the [allowed Pod disruptions documentation](https://docs.stackable.tech/home/24.7/concepts/operations/pod_disruptions).
                           properties:
                             enabled:
                               default: true
@@ -10952,7 +10952,7 @@ spec:
                                   nodeSelector: null
                                   podAffinity: null
                                   podAntiAffinity: null
-                                description: These configuration settings control [Pod placement](https://docs.stackable.tech/home/nightly/concepts/operations/pod_placement).
+                                description: These configuration settings control [Pod placement](https://docs.stackable.tech/home/24.7/concepts/operations/pod_placement).
                                 properties:
                                   nodeAffinity:
                                     description: Node affinity is a group of node affinity scheduling rules.
@@ -11474,7 +11474,7 @@ spec:
                                 default:
                                   containers: {}
                                   enableVectorAgent: null
-                                description: Logging configuration, learn more in the [logging concept documentation](https://docs.stackable.tech/home/nightly/concepts/logging).
+                                description: Logging configuration, learn more in the [logging concept documentation](https://docs.stackable.tech/home/24.7/concepts/logging).
                                 properties:
                                   containers:
                                     additionalProperties:
@@ -11599,17 +11599,17 @@ spec:
                                 type: string
                               type: object
                             default: {}
-                            description: The `configOverrides` can be used to configure properties in product config files that are not exposed in the CRD. Read the [config overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#config-overrides) and consult the operator specific usage guide documentation for details on the available config files and settings for the specific product.
+                            description: The `configOverrides` can be used to configure properties in product config files that are not exposed in the CRD. Read the [config overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#config-overrides) and consult the operator specific usage guide documentation for details on the available config files and settings for the specific product.
                             type: object
                           envOverrides:
                             additionalProperties:
                               type: string
                             default: {}
-                            description: '`envOverrides` configure environment variables to be set in the Pods. It is a map from strings to strings - environment variables and the value to set. Read the [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides) for more information and consult the operator specific usage guide to find out about the product specific environment variables that are available.'
+                            description: '`envOverrides` configure environment variables to be set in the Pods. It is a map from strings to strings - environment variables and the value to set. Read the [environment variable overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#env-overrides) for more information and consult the operator specific usage guide to find out about the product specific environment variables that are available.'
                             type: object
                           podOverrides:
                             default: {}
-                            description: In the `podOverrides` property you can define a [PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core) to override any property that can be set on a Kubernetes Pod. Read the [Pod overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#pod-overrides) for more information.
+                            description: In the `podOverrides` property you can define a [PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core) to override any property that can be set on a Kubernetes Pod. Read the [Pod overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#pod-overrides) for more information.
                             properties:
                               metadata:
                                 properties:
@@ -14531,7 +14531,7 @@ spec:
                             nodeSelector: null
                             podAffinity: null
                             podAntiAffinity: null
-                          description: These configuration settings control [Pod placement](https://docs.stackable.tech/home/nightly/concepts/operations/pod_placement).
+                          description: These configuration settings control [Pod placement](https://docs.stackable.tech/home/24.7/concepts/operations/pod_placement).
                           properties:
                             nodeAffinity:
                               description: Node affinity is a group of node affinity scheduling rules.
@@ -15053,7 +15053,7 @@ spec:
                           default:
                             containers: {}
                             enableVectorAgent: null
-                          description: Logging configuration, learn more in the [logging concept documentation](https://docs.stackable.tech/home/nightly/concepts/logging).
+                          description: Logging configuration, learn more in the [logging concept documentation](https://docs.stackable.tech/home/24.7/concepts/logging).
                           properties:
                             containers:
                               additionalProperties:
@@ -15178,17 +15178,17 @@ spec:
                           type: string
                         type: object
                       default: {}
-                      description: The `configOverrides` can be used to configure properties in product config files that are not exposed in the CRD. Read the [config overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#config-overrides) and consult the operator specific usage guide documentation for details on the available config files and settings for the specific product.
+                      description: The `configOverrides` can be used to configure properties in product config files that are not exposed in the CRD. Read the [config overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#config-overrides) and consult the operator specific usage guide documentation for details on the available config files and settings for the specific product.
                       type: object
                     envOverrides:
                       additionalProperties:
                         type: string
                       default: {}
-                      description: '`envOverrides` configure environment variables to be set in the Pods. It is a map from strings to strings - environment variables and the value to set. Read the [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides) for more information and consult the operator specific usage guide to find out about the product specific environment variables that are available.'
+                      description: '`envOverrides` configure environment variables to be set in the Pods. It is a map from strings to strings - environment variables and the value to set. Read the [environment variable overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#env-overrides) for more information and consult the operator specific usage guide to find out about the product specific environment variables that are available.'
                       type: object
                     podOverrides:
                       default: {}
-                      description: In the `podOverrides` property you can define a [PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core) to override any property that can be set on a Kubernetes Pod. Read the [Pod overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#pod-overrides) for more information.
+                      description: In the `podOverrides` property you can define a [PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core) to override any property that can be set on a Kubernetes Pod. Read the [Pod overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#pod-overrides) for more information.
                       properties:
                         metadata:
                           properties:
@@ -18098,7 +18098,7 @@ spec:
 
                             1. If PodDisruptionBudgets are created by the operator 2. The allowed number of Pods to be unavailable (`maxUnavailable`)
 
-                            Learn more in the [allowed Pod disruptions documentation](https://docs.stackable.tech/home/nightly/concepts/operations/pod_disruptions).
+                            Learn more in the [allowed Pod disruptions documentation](https://docs.stackable.tech/home/24.7/concepts/operations/pod_disruptions).
                           properties:
                             enabled:
                               default: true
@@ -18129,7 +18129,7 @@ spec:
                                   nodeSelector: null
                                   podAffinity: null
                                   podAntiAffinity: null
-                                description: These configuration settings control [Pod placement](https://docs.stackable.tech/home/nightly/concepts/operations/pod_placement).
+                                description: These configuration settings control [Pod placement](https://docs.stackable.tech/home/24.7/concepts/operations/pod_placement).
                                 properties:
                                   nodeAffinity:
                                     description: Node affinity is a group of node affinity scheduling rules.
@@ -18651,7 +18651,7 @@ spec:
                                 default:
                                   containers: {}
                                   enableVectorAgent: null
-                                description: Logging configuration, learn more in the [logging concept documentation](https://docs.stackable.tech/home/nightly/concepts/logging).
+                                description: Logging configuration, learn more in the [logging concept documentation](https://docs.stackable.tech/home/24.7/concepts/logging).
                                 properties:
                                   containers:
                                     additionalProperties:
@@ -18776,17 +18776,17 @@ spec:
                                 type: string
                               type: object
                             default: {}
-                            description: The `configOverrides` can be used to configure properties in product config files that are not exposed in the CRD. Read the [config overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#config-overrides) and consult the operator specific usage guide documentation for details on the available config files and settings for the specific product.
+                            description: The `configOverrides` can be used to configure properties in product config files that are not exposed in the CRD. Read the [config overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#config-overrides) and consult the operator specific usage guide documentation for details on the available config files and settings for the specific product.
                             type: object
                           envOverrides:
                             additionalProperties:
                               type: string
                             default: {}
-                            description: '`envOverrides` configure environment variables to be set in the Pods. It is a map from strings to strings - environment variables and the value to set. Read the [environment variable overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#env-overrides) for more information and consult the operator specific usage guide to find out about the product specific environment variables that are available.'
+                            description: '`envOverrides` configure environment variables to be set in the Pods. It is a map from strings to strings - environment variables and the value to set. Read the [environment variable overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#env-overrides) for more information and consult the operator specific usage guide to find out about the product specific environment variables that are available.'
                             type: object
                           podOverrides:
                             default: {}
-                            description: In the `podOverrides` property you can define a [PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core) to override any property that can be set on a Kubernetes Pod. Read the [Pod overrides documentation](https://docs.stackable.tech/home/nightly/concepts/overrides#pod-overrides) for more information.
+                            description: In the `podOverrides` property you can define a [PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podtemplatespec-v1-core) to override any property that can be set on a Kubernetes Pod. Read the [Pod overrides documentation](https://docs.stackable.tech/home/24.7/concepts/overrides#pod-overrides) for more information.
                             properties:
                               metadata:
                                 properties:

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,3 +1,4 @@
 ---
 name: home
-version: "nightly"
+version: "24.7"
+prerelease: false

--- a/docs/modules/hbase/examples/getting_started/getting_started.sh
+++ b/docs/modules/hbase/examples/getting_started/getting_started.sh
@@ -31,20 +31,20 @@ cd "$(dirname "$0")"
 
 case "$1" in
 "helm")
-echo "Adding 'stackable-dev' Helm Chart repository"
+echo "Adding 'stackable-stable' Helm Chart repository"
 # tag::helm-add-repo[]
-helm repo add stackable-dev https://repo.stackable.tech/repository/helm-dev/
+helm repo add stackable-stable https://repo.stackable.tech/repository/helm-stable/
 # end::helm-add-repo[]
 echo "Updating Helm repo"
 helm repo update
 echo "Installing Operators with Helm"
 # tag::helm-install-operators[]
-helm install --wait zookeeper-operator stackable-dev/zookeeper-operator --version 0.0.0-dev &
-helm install --wait hdfs-operator stackable-dev/hdfs-operator --version 0.0.0-dev &
-helm install --wait commons-operator stackable-dev/commons-operator --version 0.0.0-dev &
-helm install --wait secret-operator stackable-dev/secret-operator --version 0.0.0-dev &
-helm install --wait listener-operator stackable-dev/listener-operator --version 0.0.0-dev &
-helm install --wait hbase-operator stackable-dev/hbase-operator --version 0.0.0-dev &
+helm install --wait zookeeper-operator stackable-stable/zookeeper-operator --version 24.7.0 &
+helm install --wait hdfs-operator stackable-stable/hdfs-operator --version 24.7.0 &
+helm install --wait commons-operator stackable-stable/commons-operator --version 24.7.0 &
+helm install --wait secret-operator stackable-stable/secret-operator --version 24.7.0 &
+helm install --wait listener-operator stackable-stable/listener-operator --version 24.7.0 &
+helm install --wait hbase-operator stackable-stable/hbase-operator --version 24.7.0 &
 wait
 # end::helm-install-operators[]
 ;;
@@ -52,12 +52,12 @@ wait
 echo "installing Operators with stackablectl"
 # tag::stackablectl-install-operators[]
 stackablectl operator install \
-  commons=0.0.0-dev \
-  secret=0.0.0-dev \
-  listener=0.0.0-dev \
-  zookeeper=0.0.0-dev \
-  hdfs=0.0.0-dev \
-  hbase=0.0.0-dev
+  commons=24.7.0 \
+  secret=24.7.0 \
+  listener=24.7.0 \
+  zookeeper=24.7.0 \
+  hdfs=24.7.0 \
+  hbase=24.7.0
 # end::stackablectl-install-operators[]
 ;;
 *)

--- a/docs/modules/hbase/examples/getting_started/install_output.txt
+++ b/docs/modules/hbase/examples/getting_started/install_output.txt
@@ -1,6 +1,6 @@
-Installed commons=0.0.0-dev operator
-Installed secret=0.0.0-dev operator
-Installed listener=0.0.0-dev operator
-Installed zookeeper=0.0.0-dev operator
-Installed hdfs=0.0.0-dev operator
-Installed hbase=0.0.0-dev operator
+Installed commons=24.7.0 operator
+Installed secret=24.7.0 operator
+Installed listener=24.7.0 operator
+Installed zookeeper=24.7.0 operator
+Installed hdfs=24.7.0 operator
+Installed hbase=24.7.0 operator

--- a/docs/modules/hbase/examples/getting_started/zk.yaml
+++ b/docs/modules/hbase/examples/getting_started/zk.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.8.3
+    productVersion: 3.9.2
   servers:
     roleGroups:
       default:

--- a/docs/modules/hbase/examples/getting_started/zk.yaml.j2
+++ b/docs/modules/hbase/examples/getting_started/zk.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.8.3
+    productVersion: 3.9.2
   servers:
     roleGroups:
       default:

--- a/docs/modules/hbase/examples/usage-guide/hbck2-job.yaml
+++ b/docs/modules/hbase/examples/usage-guide/hbck2-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: hbck2
-        image: docker.stackable.tech/stackable/hbase:2.4.18-stackable0.0.0-dev
+        image: docker.stackable.tech/stackable/hbase:2.4.18-stackable24.7.0
         volumeMounts:
         - name: hbase-config
           mountPath: /stackable/conf

--- a/docs/modules/hbase/examples/usage-guide/snapshot-export-job.yaml
+++ b/docs/modules/hbase/examples/usage-guide/snapshot-export-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: hbase
-        image: docker.stackable.tech/stackable/hbase:2.4.18-stackable0.0.0-dev
+        image: docker.stackable.tech/stackable/hbase:2.4.18-stackable24.7.0
         volumeMounts:
         - name: hbase-config
           mountPath: /stackable/conf

--- a/docs/templating_vars.yaml
+++ b/docs/templating_vars.yaml
@@ -1,11 +1,11 @@
 ---
 helm:
-  repo_name: stackable-dev
-  repo_url: https://repo.stackable.tech/repository/helm-dev/
+  repo_name: stackable-stable
+  repo_url: https://repo.stackable.tech/repository/helm-stable/
 versions:
-  commons: 0.0.0-dev
-  secret: 0.0.0-dev
-  listener: 0.0.0-dev
-  zookeeper: 0.0.0-dev
-  hdfs: 0.0.0-dev
-  hbase: 0.0.0-dev
+  commons: 24.7.0
+  secret: 24.7.0
+  listener: 24.7.0
+  zookeeper: 24.7.0
+  hdfs: 24.7.0
+  hbase: 24.7.0

--- a/tests/release.yaml
+++ b/tests/release.yaml
@@ -7,16 +7,16 @@ releases:
     description: Integration test
     products:
       commons:
-        operatorVersion: 0.0.0-dev
+        operatorVersion: 24.7.0
       secret:
-        operatorVersion: 0.0.0-dev
+        operatorVersion: 24.7.0
       listener:
-        operatorVersion: 0.0.0-dev
+        operatorVersion: 24.7.0
       zookeeper:
-        operatorVersion: 0.0.0-dev
+        operatorVersion: 24.7.0
       hdfs:
-        operatorVersion: 0.0.0-dev
+        operatorVersion: 24.7.0
       hbase:
-        operatorVersion: 0.0.0-dev
+        operatorVersion: 24.7.0
       opa:
-        operatorVersion: 0.0.0-dev
+        operatorVersion: 24.7.0


### PR DESCRIPTION
ZooKeeper 3.8.3 has been removed in Stackable 24.7.
Upgrade to 3.9.2 (LTS).

- [ ] Tests pass/getting_started
- [ ] Cherry pick this commit back into `main` _todo: add link to PR_