### PR TITLE
docs: remove home module from refs (stackabletech/documentation#637) / 23.4

### DIFF
--- a/docs/modules/hbase/pages/usage-guide/logging.adoc
+++ b/docs/modules/hbase/pages/usage-guide/logging.adoc
@@ -23,4 +23,4 @@ spec:
 ----
 
 Further information on how to configure logging, can be found in
-xref:home:concepts:logging.adoc[].
+xref:concepts:logging.adoc[].

--- a/docs/modules/hbase/pages/usage-guide/monitoring.adoc
+++ b/docs/modules/hbase/pages/usage-guide/monitoring.adoc
@@ -1,4 +1,4 @@
 = Monitoring
 
 The managed HBase instances are automatically configured to export Prometheus metrics. See
-xref:home:operators:monitoring.adoc[] for more details.
+xref:operators:monitoring.adoc[] for more details.

--- a/docs/modules/hbase/pages/usage-guide/resource-requests.adoc
+++ b/docs/modules/hbase/pages/usage-guide/resource-requests.adoc
@@ -1,6 +1,6 @@
 = Resource requests
 
-include::home:concepts:stackable_resource_requests.adoc[]
+include::concepts:stackable_resource_requests.adoc[]
 
 If no resources are configured explicitly, the HBase operator uses following defaults:
 


### PR DESCRIPTION
# Description

docs: remove home module from refs (stackabletech/documentation#637) / 23.4