### PR TITLE
docs: remove home module from refs (stackabletech/documentation#637) / 24.3

### DIFF
--- a/docs/modules/hbase/pages/usage-guide/logging.adoc
+++ b/docs/modules/hbase/pages/usage-guide/logging.adoc
@@ -23,4 +23,4 @@ spec:
 ----
 
 Further information on how to configure logging, can be found in
-xref:home:concepts:logging.adoc[].
+xref:concepts:logging.adoc[].

--- a/docs/modules/hbase/pages/usage-guide/monitoring.adoc
+++ b/docs/modules/hbase/pages/usage-guide/monitoring.adoc
@@ -1,4 +1,4 @@
 = Monitoring
 
 The managed HBase instances are automatically configured to export Prometheus metrics. See
-xref:home:operators:monitoring.adoc[] for more details.
+xref:operators:monitoring.adoc[] for more details.

--- a/docs/modules/hbase/pages/usage-guide/resource-requests.adoc
+++ b/docs/modules/hbase/pages/usage-guide/resource-requests.adoc
@@ -1,6 +1,6 @@
 = Resource requests
 
-include::home:concepts:stackable_resource_requests.adoc[]
+include::concepts:stackable_resource_requests.adoc[]
 
 If no resources are configured explicitly, the HBase operator uses following defaults:
 

--- a/docs/modules/hbase/pages/usage-guide/security.adoc
+++ b/docs/modules/hbase/pages/usage-guide/security.adoc
@@ -3,14 +3,14 @@
 == Authentication
 Currently the only supported authentication mechanism is Kerberos, which is disabled by default.
 For Kerberos to work a Kerberos KDC is needed, which the users need to provide.
-The xref:home:secret-operator:secretclass.adoc#backend-kerberoskeytab[secret-operator documentation] states which kind of Kerberos servers are supported and how they can be configured.
+The xref:secret-operator:secretclass.adoc#backend-kerberoskeytab[secret-operator documentation] states which kind of Kerberos servers are supported and how they can be configured.
 
 === 1. Prepare Kerberos server
 To configure HDFS to use Kerberos you first need to collect information about your Kerberos server, e.g. hostname and port.
 Additionally, you need a service-user which the secret-operator uses to create principals for the HDFS services.
 
 === 2. Create Kerberos SecretClass
-Afterwards you need to enter all the needed information into a SecretClass, as described in xref:home:secret-operator:secretclass.adoc#backend-kerberoskeytab[secret-operator documentation].
+Afterwards you need to enter all the needed information into a SecretClass, as described in xref:secret-operator:secretclass.adoc#backend-kerberoskeytab[secret-operator documentation].
 The following guide assumes you have named your SecretClass `kerberos`.
 
 === 3. Configure HDFS to use SecretClass


### PR DESCRIPTION
# Description

docs: remove home module from refs (stackabletech/documentation#637) / 24.3