### PR TITLE
docs: remove home module from refs (stackabletech/documentation#637) / 24.7

### DIFF
--- a/docs/modules/hbase/pages/usage-guide/resource-requests.adoc
+++ b/docs/modules/hbase/pages/usage-guide/resource-requests.adoc
@@ -1,6 +1,6 @@
 = Resource requests
 
-include::home:concepts:stackable_resource_requests.adoc[]
+include::concepts:stackable_resource_requests.adoc[]
 
 If no resources are configured explicitly, the HBase operator uses following defaults:
 


### PR DESCRIPTION
# Description

docs: remove home module from refs (stackabletech/documentation#637) / 24.7