### PR TITLE
docs: Describe how to use ADLS instead of HDFS

### DIFF
--- a/docs/modules/hbase/pages/usage-guide/adls.adoc
+++ b/docs/modules/hbase/pages/usage-guide/adls.adoc
@@ -1,0 +1,92 @@
+= Using the Azure Data Lake Storage (ADLS)
+:description: Use the Azure Data Lake Storage (ADLS) instead of HDFS for HBase.
+:abfs-authentication: https://hadoop.apache.org/docs/stable/hadoop-azure/abfs.html#Authentication
+:hadoop-18516: https://issues.apache.org/jira/browse/HADOOP-18516
+
+Instead of HDFS, the HBase data can be stored in the Azure Data Lake Storage (ADLS).
+HDFS is then not required anymore to run HBase.
+
+A custom ConfigMap for ADLS containing the core-site.xml and an empty hdfs-site.xml must be provided:
+
+[source,yaml]
+----
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: adls
+data:
+  core-site.xml: |-
+    <?xml version="1.0"?>
+    <configuration>
+      <property>
+        <name>fs.defaultFS</name>  <!--1-->
+        <value>abfs://<container-name>@<storage-account>.dfs.core.windows.net/</value>
+      </property>
+      <property>
+        <name>fs.azure.account.auth.type.<storage-account>.dfs.core.windows.net</name>  <!--2-->
+        <value>SAS</value>
+      </property>
+      <property>
+        <name>fs.azure.sas.fixed.token.<storage-account>.dfs.core.windows.net</name>  <!--3-->
+        <value>${env.SAS_TOKEN}</value>
+      </property>
+      <!-- Add further properties, e.g. for Kerberos. -->
+    </configuration>
+  hdfs-site.xml: |-
+    <?xml version="1.0"?>
+    <configuration>
+    </configuration>
+----
+<1> The name of the default file system.
+The `hadoop-azure` module which provides support for ADLS through the "abfs" connector, is already contained in the Stackable HBase image and accessible on the classpath.
+Make sure that the hierarchical namespace is enabled in the storage account.
+Replace `<container-name>` and `<storage-account>` accordingly.
+<2> The authentication mechanism.
+Possible values are `SharedKey`, `OAuth`, `Custom` and `SAS`, see the {abfs-authentication}[documentation] of the `hadoop-azure` module for further information.
+<3> If the authentication type is set to `SAS` (shared access signature) and no SAS token provider is given in `fs.azure.sas.token.provider.type`, then a fixed SAS token can be used instead.
+The `FixedSASTokenProvider` (see {hadoop-18516}[HADOOP-18516]) is back-ported to all supported HBase versions, so that the SAS token can be configured with this property.
+
+The ConfigMap must be referenced in `hdfsConfigMapName`.
+In the example above, the SAS token is read from an environment variable which is taken from a Secret:
+
+[source,yaml]
+----
+---
+apiVersion: hbase.stackable.tech/v1alpha1
+kind: HbaseCluster
+spec:
+  clusterConfig:
+    hdfsConfigMapName: adls
+  masters:
+    podOverrides:
+      spec:
+        containers:
+        - name: hbase
+          env:
+          - name: SAS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: adls-credentials
+                key: sas-token
+  regionServers:
+    podOverrides:
+      spec:
+        containers:
+        - name: hbase
+          env:
+          - name: SAS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: adls-credentials
+                key: sas-token
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: adls-credentials
+type: Opaque
+data:
+  # decoded sas-token: sp=racwdlmeop&st=2024-01-01T00:00:00Z&se=2025-01-01T00:00:00Z&spr=https&sv=2022-11-02&sr=c&sig=xxx
+  sas-token: c3A9cmFjd2RsbWVvcCZzdD0yMDI0LTAxLTAxVDAwOjAwOjAwWiZzZT0yMDI1LTAxLTAxVDAwOjAwOjAwWiZzcHI9aHR0cHMmc3Y9MjAyMi0xMS0wMiZzcj1jJnNpZz14eHgK
+----

--- a/docs/modules/hbase/partials/nav.adoc
+++ b/docs/modules/hbase/partials/nav.adoc
@@ -12,6 +12,7 @@
 ** xref:hbase:usage-guide/overrides.adoc[]
 ** xref:hbase:usage-guide/hbck2.adoc[]
 ** xref:hbase:usage-guide/snapshot-export.adoc[]
+** xref:hbase:usage-guide/adls.adoc[]
 ** xref:hbase:usage-guide/operations/index.adoc[]
 *** xref:hbase:usage-guide/operations/cluster-operations.adoc[]
 *** xref:hbase:usage-guide/operations/pod-placement.adoc[]


### PR DESCRIPTION
# Description

Describe how to use ADLS instead of HDFS

The ADLS support could also be properly implemented into the operator. The CRD could be extended and the operator could create the ConfigMap for ADLS. On the one hand, this would be a lot of work, on the other hand, this cannot be tested without an actual Azure storage account. Azure storage clones like Azurite do currently not support ADLS Gen2, see 
[Azure/Azurite#553](https://www.github.com/Azure/Azurite/issues/553). Adding a feature which cannot be integrated into Stackable's test landscape, is not sensible. And as the hurdle is low for the customer to define the ADLS ConfigMap themselves, only a documentation is provided.

Closes #539 

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
