### PR TITLE
Fix bug where the configuration of the hbaseRootdir at the role level is ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Reduce CRD size from `1.4MB` to `96KB` by accepting arbitrary YAML input instead of the underlying schema for the following fields ([#548]):
   - `podOverrides`
   - `affinity`
+- Fix bug where the configuration of the `hbaseRootdir` at the role level is ignored ([#584]).
 
 ### Fixed
 
@@ -28,6 +29,7 @@
 [#556]: https://github.com/stackabletech/hbase-operator/pull/556
 [#558]: https://github.com/stackabletech/hbase-operator/pull/558
 [#574]: https://github.com/stackabletech/hbase-operator/pull/574
+[#584]: https://github.com/stackabletech/hbase-operator/pull/584
 
 ## [24.7.0] - 2024-07-24
 

--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -213,14 +213,14 @@ properties:
         type: "string"
       defaultValues:
         - fromVersion: "0.0.0"
-          value: "${hbase.tmp.dir}/hbase"
+          value: "/hbase"
       roles:
         - name: "master"
-          required: false
+          required: true # TODO: this could be false?
         - name: "regionserver"
-          required: false
+          required: true
         - name: "restserver"
-          required: false
+          required: true # TODO: this could be false?
       asOfVersion: "0.0.0"
       description: "The directory shared by region servers and into which HBase persists. The URL should be 'fully-qualified' to include the filesystem scheme. For example, to specify the HDFS directory '/hbase' where the HDFS instance's namenode is running at namenode.example.org on port 9000, set this value to: hdfs://namenode.example.org:9000/hbase. By default, we write to whatever ${hbase.tmp.dir} is set too -- usually /tmp -- so change this configuration or else all data will be lost on machine restart."
 

--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -216,11 +216,11 @@ properties:
           value: "/hbase"
       roles:
         - name: "master"
-          required: true # TODO: this could be false?
-        - name: "regionserver"
           required: true
+        - name: "regionserver"
+          required: true # this can be false (only required for master) - kept for compatibility (avoid restarts)
         - name: "restserver"
-          required: true # TODO: this could be false?
+          required: true # this can be false (only required for master) - kept for compatibility (avoid restarts)
       asOfVersion: "0.0.0"
       description: "The directory shared by region servers and into which HBase persists. The URL should be 'fully-qualified' to include the filesystem scheme. For example, to specify the HDFS directory '/hbase' where the HDFS instance's namenode is running at namenode.example.org on port 9000, set this value to: hdfs://namenode.example.org:9000/hbase. By default, we write to whatever ${hbase.tmp.dir} is set too -- usually /tmp -- so change this configuration or else all data will be lost on machine restart."
 

--- a/deploy/helm/hbase-operator/configs/properties.yaml
+++ b/deploy/helm/hbase-operator/configs/properties.yaml
@@ -213,14 +213,14 @@ properties:
         type: "string"
       defaultValues:
         - fromVersion: "0.0.0"
-          value: "${hbase.tmp.dir}/hbase"
+          value: "/hbase"
       roles:
         - name: "master"
-          required: false
+          required: true # TODO: this could be false?
         - name: "regionserver"
-          required: false
+          required: true
         - name: "restserver"
-          required: false
+          required: true # TODO: this could be false?
       asOfVersion: "0.0.0"
       description: "The directory shared by region servers and into which HBase persists. The URL should be 'fully-qualified' to include the filesystem scheme. For example, to specify the HDFS directory '/hbase' where the HDFS instance's namenode is running at namenode.example.org on port 9000, set this value to: hdfs://namenode.example.org:9000/hbase. By default, we write to whatever ${hbase.tmp.dir} is set too -- usually /tmp -- so change this configuration or else all data will be lost on machine restart."
 

--- a/deploy/helm/hbase-operator/configs/properties.yaml
+++ b/deploy/helm/hbase-operator/configs/properties.yaml
@@ -216,11 +216,11 @@ properties:
           value: "/hbase"
       roles:
         - name: "master"
-          required: true # TODO: this could be false?
-        - name: "regionserver"
           required: true
+        - name: "regionserver"
+          required: true # this can be false (only required for master) - kept for compatibility (avoid restarts)
         - name: "restserver"
-          required: true # TODO: this could be false?
+          required: true # this can be false (only required for master) - kept for compatibility (avoid restarts)
       asOfVersion: "0.0.0"
       description: "The directory shared by region servers and into which HBase persists. The URL should be 'fully-qualified' to include the filesystem scheme. For example, to specify the HDFS directory '/hbase' where the HDFS instance's namenode is running at namenode.example.org on port 9000, set this value to: hdfs://namenode.example.org:9000/hbase. By default, we write to whatever ${hbase.tmp.dir} is set too -- usually /tmp -- so change this configuration or else all data will be lost on machine restart."
 

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -473,15 +473,7 @@ impl Configuration for HbaseConfigFragment {
                     HBASE_UNSAFE_REGIONSERVER_HOSTNAME_DISABLE_MASTER_REVERSEDNS.to_string(),
                     Some("true".to_string()),
                 );
-                result.insert(
-                    HBASE_ROOTDIR.to_string(),
-                    Some(
-                        self.hbase_rootdir
-                            .as_deref()
-                            .unwrap_or(HBASE_ROOT_DIR_DEFAULT)
-                            .to_string(),
-                    ),
-                );
+                result.insert(HBASE_ROOTDIR.to_string(), self.hbase_rootdir.clone());
             }
             _ => {}
         }

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -59,7 +59,6 @@ pub const HBASE_ROOTDIR: &str = "hbase.rootdir";
 pub const HBASE_UNSAFE_REGIONSERVER_HOSTNAME_DISABLE_MASTER_REVERSEDNS: &str =
     "hbase.unsafe.regionserver.hostname.disable.master.reversedns";
 pub const HBASE_HEAPSIZE: &str = "HBASE_HEAPSIZE";
-pub const HBASE_ROOT_DIR_DEFAULT: &str = "/hbase";
 
 pub const HBASE_UI_PORT_NAME_HTTP: &str = "ui-http";
 pub const HBASE_UI_PORT_NAME_HTTPS: &str = "ui-https";


### PR DESCRIPTION
# Description

The problem was defaulting in the product config callbacks like:

```
 result.insert( 
     HBASE_ROOTDIR.to_string(), 
     Some( 
         self.hbase_rootdir 
             .as_deref() 
             .unwrap_or(HBASE_ROOT_DIR_DEFAULT) 
             .to_string(), 
     ), 
 ); 
```

If the `hbaseRootdir` was only set on the role, we defaulted the rolegroup to `HBASE_ROOT_DIR_DEFAULT` ("/hbase"), which during merging overrode the value set on the role. The solution here is to remove the defaulting and it works.
One problem remained, if `hbaseRootdir` was not set at all, there was no default set anymore. The product config did not add the default due to the field being marked as not required.
In order to keep the defaulting behavior as is and not mess with existing defaulted installation, the default for `hbase.root.dir` in the product config was changed to "/hbase" and the field marked as required (on all roles).
The docs state though:
```
The directory shared by region servers and into which HBase persists. The URL should be 'fully-qualified' to include the filesystem scheme. For example, to specify the HDFS directory '/hbase' where the HDFS instance's namenode is running at namenode.example.org on port 9000, set this value to: hdfs://namenode.example.org:9000/hbase. By default, we write to whatever ${hbase.tmp.dir} is set too -- usually /tmp -- so change this configuration or else all data will be lost on machine restart.
```

So i think we can only use it on the regionservers? Ping @lfrancke 

Edit: Lars would bet its at least required in the masters, so i would keep it as is (required in all roles in the product config)

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] (Integration-)Test cases added
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
