### PR TITLE
tests: Add OPA as a test dimension (main)

### DIFF
--- a/tests/templates/kuttl/opa/11-install-opa.yaml.j2
+++ b/tests/templates/kuttl/opa/11-install-opa.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: opa
 spec:
   image:
-    productVersion: 0.61.0
+    productVersion: "{{ test_scenario['values']['opa'] }}"
     pullPolicy: IfNotPresent
   servers:
     roleGroups:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -33,6 +33,9 @@ dimensions:
   - name: krb5
     values:
       - 1.21.1
+  - name: opa
+    values:
+      - 0.67.1
   # Used for zookeeper, hdfs and hbase
   - name: listener-class
     values:
@@ -81,6 +84,7 @@ tests:
       - zookeeper-latest
       - krb5
       - openshift
+      - opa
   - name: orphaned_resources
     dimensions:
       - hbase-latest


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/647.

Replace hard-coded OPA version with a templated dimension.

There is a companion change for the release-24.11 branch: #593.
Similar change made here https://github.com/stackabletech/hdfs-operator/pull/614.