### PR TITLE
chore: add oci references, merge templating changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@
 - Run a `containerdebug` process in the background of each HBase container to collect debugging information ([#605]).
 - Aggregate emitted Kubernetes events on the CustomResources ([#612]).
 
+### Changed
+
+- Default to OCI for image metadata and product image selection ([#611]).
+
 [#598]: https://github.com/stackabletech/hbase-operator/pull/598
 [#605]: https://github.com/stackabletech/hbase-operator/pull/605
+[#611]: https://github.com/stackabletech/hbase-operator/pull/611
 [#612]: https://github.com/stackabletech/hbase-operator/pull/612
 
 ## [24.11.1] - 2025-01-09

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,8 +2370,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.84.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.1#b8fe43f7368249bf95b06d6cba3fd0135f7523ac"
+version = "0.85.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#59506c6202778889a27b6ae8153457e60a49c68d"
 dependencies = [
  "chrono",
  "clap",
@@ -2409,7 +2409,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.1#b8fe43f7368249bf95b06d6cba3fd0135f7523ac"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#59506c6202778889a27b6ae8153457e60a49c68d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2420,7 +2420,7 @@ dependencies = [
 [[package]]
 name = "stackable-shared"
 version = "0.0.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.1#b8fe43f7368249bf95b06d6cba3fd0135f7523ac"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#59506c6202778889a27b6ae8153457e60a49c68d"
 dependencies = [
  "kube",
  "semver",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -7382,13 +7382,13 @@ rec {
       };
       "stackable-operator" = rec {
         crateName = "stackable-operator";
-        version = "0.84.1";
+        version = "0.85.0";
         edition = "2021";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "b8fe43f7368249bf95b06d6cba3fd0135f7523ac";
-          sha256 = "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i";
+          rev = "59506c6202778889a27b6ae8153457e60a49c68d";
+          sha256 = "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5";
         };
         libName = "stackable_operator";
         authors = [
@@ -7547,8 +7547,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "b8fe43f7368249bf95b06d6cba3fd0135f7523ac";
-          sha256 = "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i";
+          rev = "59506c6202778889a27b6ae8153457e60a49c68d";
+          sha256 = "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5";
         };
         procMacro = true;
         libName = "stackable_operator_derive";
@@ -7582,8 +7582,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "b8fe43f7368249bf95b06d6cba3fd0135f7523ac";
-          sha256 = "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i";
+          rev = "59506c6202778889a27b6ae8153457e60a49c68d";
+          sha256 = "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5";
         };
         libName = "stackable_shared";
         authors = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 snafu = "0.8"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.84.1" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.85.0" }
 product-config = { git = "https://github.com/stackabletech/product-config.git", tag = "0.7.0" }
 strum = { version = "0.26", features = ["derive"] }
 tokio = { version = "1.40", features = ["full"] }

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,6 +1,6 @@
 {
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.1#stackable-operator-derive@0.3.1": "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.1#stackable-operator@0.84.1": "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.84.1#stackable-shared@0.0.1": "0vwq3dzxj56y4vrnw4ry7wajm12f32jipvc6f3izdrixy2pazq3i",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#stackable-operator-derive@0.3.1": "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#stackable-operator@0.85.0": "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.85.0#stackable-shared@0.0.1": "0rh476rmn5850yj85hq8znwmlfhd7l5bkxz0n5i9m4cddxhi2cl5",
   "git+https://github.com/stackabletech/product-config.git?tag=0.7.0#product-config@0.7.0": "0gjsm80g6r75pm3824dcyiz4ysq1ka4c1if6k1mjm9cnd5ym0gny"
 }

--- a/deploy/helm/hbase-operator/crds/crds.yaml
+++ b/deploy/helm/hbase-operator/crds/crds.yaml
@@ -126,7 +126,7 @@ spec:
                     Consult the [Product image selection documentation](https://docs.stackable.tech/home/nightly/concepts/product_image_selection) for details.
                   properties:
                     custom:
-                      description: Overwrite the docker image. Specify the full docker image name, e.g. `docker.stackable.tech/stackable/superset:1.4.1-stackable2.1.0`
+                      description: Overwrite the docker image. Specify the full docker image name, e.g. `oci.stackable.tech/sdp/superset:1.4.1-stackable2.1.0`
                       type: string
                     productVersion:
                       description: Version of the product, e.g. `1.4.1`.
@@ -153,7 +153,7 @@ spec:
                       nullable: true
                       type: array
                     repo:
-                      description: Name of the docker repo, e.g. `docker.stackable.tech/stackable`
+                      description: Name of the docker repo, e.g. `oci.stackable.tech/sdp`
                       nullable: true
                       type: string
                     stackableVersion:

--- a/deploy/helm/hbase-operator/values.yaml
+++ b/deploy/helm/hbase-operator/values.yaml
@@ -1,7 +1,7 @@
 # Default values for hbase-operator.
 ---
 image:
-  repository: docker.stackable.tech/stackable/hbase-operator
+  repository: oci.stackable.tech/sdp/hbase-operator
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/docs/modules/hbase/examples/usage-guide/hbck2-job.yaml
+++ b/docs/modules/hbase/examples/usage-guide/hbck2-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: hbck2
-        image: docker.stackable.tech/stackable/hbase:2.4.18-stackable0.0.0-dev
+        image: oci.stackable.tech/sdp/hbase:2.4.18-stackable0.0.0-dev
         volumeMounts:
         - name: hbase-config
           mountPath: /stackable/conf

--- a/docs/modules/hbase/examples/usage-guide/hbck2-job.yaml.j2
+++ b/docs/modules/hbase/examples/usage-guide/hbck2-job.yaml.j2
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: hbck2
-        image: docker.stackable.tech/stackable/hbase:2.4.18-stackable{{ versions.hbase }}
+        image: oci.stackable.tech/sdp/hbase:2.4.18-stackable{{ versions.hbase }}
         volumeMounts:
         - name: hbase-config
           mountPath: /stackable/conf

--- a/docs/modules/hbase/examples/usage-guide/snapshot-export-job.yaml
+++ b/docs/modules/hbase/examples/usage-guide/snapshot-export-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: hbase
-        image: docker.stackable.tech/stackable/hbase:2.4.18-stackable0.0.0-dev
+        image: oci.stackable.tech/sdp/hbase:2.4.18-stackable0.0.0-dev
         volumeMounts:
         - name: hbase-config
           mountPath: /stackable/conf

--- a/docs/modules/hbase/examples/usage-guide/snapshot-export-job.yaml.j2
+++ b/docs/modules/hbase/examples/usage-guide/snapshot-export-job.yaml.j2
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: hbase
-        image: docker.stackable.tech/stackable/hbase:2.4.18-stackable{{ versions.hbase }}
+        image: oci.stackable.tech/sdp/hbase:2.4.18-stackable{{ versions.hbase }}
         volumeMounts:
         - name: hbase-config
           mountPath: /stackable/conf

--- a/docs/modules/hbase/pages/reference/environment-variables.adoc
+++ b/docs/modules/hbase/pages/reference/environment-variables.adoc
@@ -30,7 +30,7 @@ docker run \
 --env KUBECONFIG=/home/stackable/.kube/config \
 --env KUBERNETES_CLUSTER_DOMAIN=mycluster.local \
 --mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
-docker.stackable.tech/stackable/hbase-operator:latest
+oci.stackable.tech/sdp/hbase-operator:0.0.0-dev
 ----
 
 == PRODUCT_CONFIG
@@ -56,7 +56,7 @@ docker run \
     --env KUBECONFIG=/home/stackable/.kube/config \
     --env PRODUCT_CONFIG=/my/product/config.yaml \
     --mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
-    docker.stackable.tech/stackable/hbase-operator:latest
+    oci.stackable.tech/sdp/hbase-operator:0.0.0-dev
 ----
 
 == WATCH_NAMESPACE
@@ -85,5 +85,5 @@ docker run \
 --env KUBECONFIG=/home/stackable/.kube/config \
 --env WATCH_NAMESPACE=test \
 --mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
-docker.stackable.tech/stackable/hbase-operator:latest
+oci.stackable.tech/sdp/hbase-operator:0.0.0-dev
 ----

--- a/rust/operator-binary/src/hbase_controller.rs
+++ b/rust/operator-binary/src/hbase_controller.rs
@@ -1298,9 +1298,7 @@ mod test {
         let hbase: HbaseCluster = serde_yaml::from_str(&input).expect("illegal test input");
 
         let resolved_image = ResolvedProductImage {
-            image: format!(
-                "docker.stackable.tech/stackable/hbase:{hbase_version}-stackable0.0.0-dev"
-            ),
+            image: format!("oci.stackable.tech/sdp/hbase:{hbase_version}-stackable0.0.0-dev"),
             app_version_label: hbase_version.to_string(),
             product_version: hbase_version.to_string(),
             image_pull_policy: "Never".to_string(),

--- a/tests/templates/kuttl/kerberos/01-install-krb5-kdc.yaml.j2
+++ b/tests/templates/kuttl/kerberos/01-install-krb5-kdc.yaml.j2
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: test-sa
       initContainers:
         - name: init
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - sh
             - -euo
@@ -36,7 +36,7 @@ spec:
               name: data
       containers:
         - name: kdc
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - krb5kdc
             - -n
@@ -54,7 +54,7 @@ spec:
             runAsUser: 0
 {% endif %}
         - name: kadmind
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - kadmind
             - -nofork
@@ -72,7 +72,7 @@ spec:
             runAsUser: 0
 {% endif %}
         - name: client
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           tty: true
           stdin: true
           env:

--- a/tests/templates/kuttl/kerberos/20-access-hdfs.yaml.j2
+++ b/tests/templates/kuttl/kerberos/20-access-hdfs.yaml.j2
@@ -15,7 +15,7 @@ commands:
             serviceAccountName: test-sa
             containers:
               - name: access-hdfs
-                image: docker.stackable.tech/stackable/hadoop:{{ test_scenario['values']['hdfs-latest'] }}-stackable0.0.0-dev
+                image: oci.stackable.tech/sdp/hadoop:{{ test_scenario['values']['hdfs-latest'] }}-stackable0.0.0-dev
                 env:
                   - name: HADOOP_CONF_DIR
                     value: /stackable/conf/hdfs

--- a/tests/templates/kuttl/kerberos/41-access-hbase.yaml.j2
+++ b/tests/templates/kuttl/kerberos/41-access-hbase.yaml.j2
@@ -18,7 +18,7 @@ commands:
 {% if test_scenario['values']['hbase'].find(",") > 0 %}
                 image: "{{ test_scenario['values']['hbase'].split(',')[1] }}"
 {% else %}
-                image: docker.stackable.tech/stackable/hbase:{{ test_scenario['values']['hbase'] }}-stackable0.0.0-dev
+                image: oci.stackable.tech/sdp/hbase:{{ test_scenario['values']['hbase'] }}-stackable0.0.0-dev
 {% endif %}
                 env:
                   - name: HBASE_CONF_DIR

--- a/tests/templates/kuttl/kerberos/42-test-rest-server.yaml
+++ b/tests/templates/kuttl/kerberos/42-test-rest-server.yaml
@@ -9,7 +9,7 @@ spec:
       serviceAccountName: test-sa
       containers:
         - name: test-rest-server
-          image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
           command:
             - /bin/bash
             - -c

--- a/tests/templates/kuttl/logging/06-install-hbase-test-runner.yaml
+++ b/tests/templates/kuttl/logging/06-install-hbase-test-runner.yaml
@@ -17,6 +17,6 @@ spec:
     spec:
       containers:
         - name: hbase-test-runner
-          image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
           stdin: true
           tty: true

--- a/tests/templates/kuttl/omid/40-install-omid.yaml.j2
+++ b/tests/templates/kuttl/omid/40-install-omid.yaml.j2
@@ -46,7 +46,7 @@ spec:
 {% if test_scenario['values']['omid'].find(",") > 0 %}
           image: "{{ test_scenario['values']['omid'].split(',')[1] }}"
 {% else %}
-          image: docker.stackable.tech/stackable/omid:{{ test_scenario['values']['omid'] }}-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/omid:{{ test_scenario['values']['omid'] }}-stackable0.0.0-dev
 {% endif %}
           imagePullPolicy: IfNotPresent
           command:

--- a/tests/templates/kuttl/opa/01-install-krb5-kdc.yaml.j2
+++ b/tests/templates/kuttl/opa/01-install-krb5-kdc.yaml.j2
@@ -14,7 +14,7 @@ spec:
       serviceAccountName: test-sa
       initContainers:
         - name: init
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - sh
             - -euo
@@ -35,7 +35,7 @@ spec:
               name: data
       containers:
         - name: kdc
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - krb5kdc
             - -n
@@ -53,7 +53,7 @@ spec:
             runAsUser: 0
 {% endif %}
         - name: kadmind
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           args:
             - kadmind
             - -nofork
@@ -71,7 +71,7 @@ spec:
             runAsUser: 0
 {% endif %}
         - name: client
-          image: docker.stackable.tech/stackable/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/krb5:{{ test_scenario['values']['krb5'] }}-stackable0.0.0-dev
           tty: true
           stdin: true
           env:

--- a/tests/templates/kuttl/opa/41-access-hbase.yaml.j2
+++ b/tests/templates/kuttl/opa/41-access-hbase.yaml.j2
@@ -18,7 +18,7 @@ commands:
 {% if test_scenario['values']['hbase-opa'].find(",") > 0 %}
                 image: "{{ test_scenario['values']['hbase-opa'].split(',')[1] }}"
 {% else %}
-                image: docker.stackable.tech/stackable/hbase:{{ test_scenario['values']['hbase-opa'] }}-stackable0.0.0-dev
+                image: oci.stackable.tech/sdp/hbase:{{ test_scenario['values']['hbase-opa'] }}-stackable0.0.0-dev
 {% endif %}
                 env:
                   - name: HBASE_CONF_DIR

--- a/tests/templates/kuttl/opa/42-test-rest-server.yaml
+++ b/tests/templates/kuttl/opa/42-test-rest-server.yaml
@@ -9,7 +9,7 @@ spec:
       serviceAccountName: test-sa
       containers:
         - name: test-rest-server
-          image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
           command:
             - /bin/bash
             - -c

--- a/tests/templates/kuttl/profiling/04-install-test-container.yaml
+++ b/tests/templates/kuttl/profiling/04-install-test-container.yaml
@@ -26,7 +26,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: python
-          image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
           stdin: true
           tty: true
           resources:

--- a/tests/templates/kuttl/smoke/40-install-hbase-test-runner.yaml
+++ b/tests/templates/kuttl/smoke/40-install-hbase-test-runner.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: hbase-test-runner
-          image: docker.stackable.tech/stackable/testing-tools:0.2.0-stackable0.0.0-dev
+          image: oci.stackable.tech/sdp/testing-tools:0.2.0-stackable0.0.0-dev
           stdin: true
           tty: true
           resources:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -5,17 +5,17 @@ dimensions:
       - 2.6.0
       - 2.4.18
       # To use a custom image, add a comma and the full name after the product version
-      # - 2.6.0,docker.stackable.tech/sandbox/hbase:2.6.0-stackable0.0.0-dev
-      # - 2.4.18,docker.stackable.tech/sandbox/hbase:2.4.18-stackable0.0.0-dev
+      # - 2.6.0,oci.stackable.tech/sandbox/hbase:2.6.0-stackable0.0.0-dev
+      # - 2.4.18,oci.stackable.tech/sandbox/hbase:2.4.18-stackable0.0.0-dev
   - name: hbase-opa
     values:
       - 2.6.0
       # To use a custom image, add a comma and the full name after the product version
-      # - 2.6.0,docker.stackable.tech/sandbox/hbase:2.6.0-stackable0.0.0-dev
+      # - 2.6.0,oci.stackable.tech/sandbox/hbase:2.6.0-stackable0.0.0-dev
   - name: hbase-latest
     values:
       - 2.6.0
-      # - 2.4.18,docker.stackable.tech/sandbox/hbase:2.4.18-stackable0.0.0-dev
+      # - 2.4.18,oci.stackable.tech/sandbox/hbase:2.4.18-stackable0.0.0-dev
   - name: hdfs
     values:
       - 3.3.4
@@ -58,7 +58,7 @@ dimensions:
     values:
       - 1.1.2
       # To use a custom image, add a comma and the full name after the product version
-      # - 1.1.0,docker.stackable.tech/sandbox/omid:1.1.0-stackable0.0.0-dev
+      # - 1.1.0,oci.stackable.tech/sandbox/omid:1.1.0-stackable0.0.0-dev
 tests:
   - name: smoke
     dimensions:


### PR DESCRIPTION
# Description

- [x] merge templating PR
- [x] change all references, use search-and-replace to find things (Makefile, Dockerfiles, operator Helm Charts, default,nix, kuttl tests, ....)
- [x] ensure that kuttl tests are running
- [x] for every image reference, ensure that the image is actually in Harbor (and image hash is the same as before?)

```
--- FAIL: kuttl (6533.87s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_hbase-2.6.0_hdfs-3.4.0_zookeeper-3.9.2_listener-class-external-unstable_openshift-false (533.79s)
        --- PASS: kuttl/harness/cluster-operation_hbase-latest-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-false (533.89s)
        --- PASS: kuttl/harness/smoke_hbase-2.6.0_hdfs-3.4.0_zookeeper-3.9.2_listener-class-cluster-internal_openshift-false (299.96s)
        --- PASS: kuttl/harness/omid_hbase-2.4.18_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-false_omid-1.1.2 (300.07s)
        --- PASS: kuttl/harness/smoke_hbase-2.6.0_hdfs-3.3.6_zookeeper-3.9.2_listener-class-cluster-internal_openshift-false (299.95s)
        --- PASS: kuttl/harness/smoke_hbase-2.6.0_hdfs-3.3.6_zookeeper-3.9.2_listener-class-external-unstable_openshift-false (299.98s)
        --- PASS: kuttl/harness/smoke_hbase-2.6.0_hdfs-3.3.4_zookeeper-3.9.2_listener-class-cluster-internal_openshift-false (299.88s)
        --- PASS: kuttl/harness/smoke_hbase-2.6.0_hdfs-3.3.4_zookeeper-3.9.2_listener-class-external-unstable_openshift-false (299.97s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.18_hdfs-3.4.0_zookeeper-3.9.2_listener-class-external-unstable_openshift-false (194.44s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.18_hdfs-3.4.0_zookeeper-3.9.2_listener-class-cluster-internal_openshift-false (300.11s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.18_hdfs-3.3.6_zookeeper-3.9.2_listener-class-cluster-internal_openshift-false (197.57s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.18_hdfs-3.3.6_zookeeper-3.9.2_listener-class-external-unstable_openshift-false (405.67s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.18_hdfs-3.3.4_zookeeper-3.9.2_listener-class-external-unstable_openshift-false (402.40s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.18_hdfs-3.3.4_zookeeper-3.9.2_listener-class-cluster-internal_openshift-false (300.05s)
        --- PASS: kuttl/harness/overrides_hbase-latest-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-false (299.97s)
        --- PASS: kuttl/harness/resources_hbase-latest-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-false (300.03s)
        --- PASS: kuttl/harness/opa_hbase-opa-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_krb5-1.21.1_opa-1.0.0_openshift-false (299.98s)
        --- PASS: kuttl/harness/omid_hbase-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-false_omid-1.1.2 (299.95s)
        --- PASS: kuttl/harness/profiling_hbase-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-false (300.36s)
        --- FAIL: kuttl/harness/kerberos_hbase-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_krb5-1.21.1_listener-class-cluster-internal_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (586.99s)
        --- PASS: kuttl/harness/profiling_hbase-2.4.18_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-false (299.62s)
        --- PASS: kuttl/harness/logging_hbase-2.4.18_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-false (139.79s)
        --- PASS: kuttl/harness/logging_hbase-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-false (313.00s)
        --- FAIL: kuttl/harness/orphaned_resources_hbase-latest-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-false (421.71s)
        --- PASS: kuttl/harness/kerberos_hbase-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_krb5-1.21.1_listener-class-external-unstable_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (600.04s)
        --- FAIL: kuttl/harness/kerberos_hbase-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_krb5-1.21.1_listener-class-external-unstable_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_openshift-false (588.04s)
        --- FAIL: kuttl/harness/kerberos_hbase-2.4.18_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_krb5-1.21.1_listener-class-cluster-internal_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (599.65s)
        --- FAIL: kuttl/harness/kerberos_hbase-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_krb5-1.21.1_listener-class-cluster-internal_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_openshift-false (606.23s)
        --- FAIL: kuttl/harness/kerberos_hbase-2.4.18_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_krb5-1.21.1_listener-class-external-unstable_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (592.97s)
        --- PASS: kuttl/harness/kerberos_hbase-2.4.18_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_krb5-1.21.1_listener-class-external-unstable_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_openshift-false (644.40s)
        --- PASS: kuttl/harness/snapshot-export_hbase-2.4.18_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-false (172.47s)
        --- FAIL: kuttl/harness/kerberos_hbase-2.4.18_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_krb5-1.21.1_listener-class-cluster-internal_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_openshift-false (589.81s)
        --- PASS: kuttl/harness/snapshot-export_hbase-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-false (427.42s)
FAIL
```
All the failed tests completed successfully, seems to be deletion flakyness.

Openshift:
```
--- FAIL: kuttl (2702.87s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/opa_hbase-opa-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_krb5-1.21.1_opa-1.0.0_openshift-true (602.55s)
        --- FAIL: kuttl/harness/orphaned_resources_hbase-latest-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-true (619.50s)
        --- PASS: kuttl/harness/cluster-operation_hbase-latest-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-true (299.92s)
        --- FAIL: kuttl/harness/logging_hbase-2.4.18_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-true (559.56s)
        --- FAIL: kuttl/harness/profiling_hbase-2.4.18_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-true (499.30s)
        --- FAIL: kuttl/harness/snapshot-export_hbase-2.4.18_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-true (523.09s)
        --- FAIL: kuttl/harness/overrides_hbase-latest-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-true (461.91s)
        --- PASS: kuttl/harness/smoke_hbase-2.4.18_hdfs-3.4.0_zookeeper-3.9.2_listener-class-external-unstable_openshift-true (400.51s)
        --- PASS: kuttl/harness/resources_hbase-latest-2.6.0_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-true (239.01s)
        --- FAIL: kuttl/harness/omid_hbase-2.4.18_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_openshift-true_omid-1.1.2 (531.38s)
        --- PASS: kuttl/harness/kerberos_hbase-2.4.18_hdfs-latest-3.4.0_zookeeper-latest-3.9.2_krb5-1.21.1_listener-class-external-unstable_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-true (600.01s)
FAIL
```
All the failed tests completed successfully, seems to be deletion flakyness.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
