### PR TITLE
chore: support for hbase 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Run a `containerdebug` process in the background of each HBase container to collect debugging information ([#605]).
 - Aggregate emitted Kubernetes events on the CustomResources ([#612]).
 - Support configuring JVM arguments ([#620]).
+- Added support for HBase 2.6.1 ([#627]):
 
 ### Removed
 
@@ -25,6 +26,7 @@
 [#611]: https://github.com/stackabletech/hbase-operator/pull/611
 [#612]: https://github.com/stackabletech/hbase-operator/pull/612
 [#620]: https://github.com/stackabletech/hbase-operator/pull/620
+[#627]: https://github.com/stackabletech/hbase-operator/pull/627
 
 ## [24.11.1] - 2025-01-09
 

--- a/docs/modules/hbase/partials/supported-versions.adoc
+++ b/docs/modules/hbase/partials/supported-versions.adoc
@@ -2,6 +2,5 @@
 // This is a separate file, since it is used by both the direct HBase-Operator documentation, and the overarching
 // Stackable Platform documentation.
 
-- 2.6.0 (Experimental)
-- 2.4.18 (LTS)
-- 2.4.17 (Deprecated)
+- 2.6.1 (LTS)
+- 2.4.18 (Deprecated)

--- a/tests/templates/kuttl/snapshot-export/30_test-export.sh
+++ b/tests/templates/kuttl/snapshot-export/30_test-export.sh
@@ -14,6 +14,7 @@ hbase shell create-snapshot.hbase 2>&1 | \
 
 # Export local snapshot to S3
 export-snapshot-to-s3 \
+        --no-checksum-verify \ # needed for HBase 2.6.1 until this is fixed: https://issues.apache.org/jira/browse/HBASE-28998
         --snapshot snap \
         --copy-to s3a://hbase/snap \
         --overwrite 2>&1 | \
@@ -25,6 +26,7 @@ hbase shell delete-snapshot.hbase 2>&1 | \
 
 # Import snapshot from S3
 export-snapshot-to-s3 \
+        --no-checksum-verify \ # needed for HBase 2.6.1 until this is fixed: https://issues.apache.org/jira/browse/HBASE-28998
         --snapshot snap \
         --copy-from s3a://hbase/snap \
         --copy-to hdfs://test-hdfs/hbase \

--- a/tests/templates/kuttl/snapshot-export/30_test-export.sh
+++ b/tests/templates/kuttl/snapshot-export/30_test-export.sh
@@ -13,8 +13,9 @@ hbase shell create-snapshot.hbase 2>&1 | \
     grep '=> \["snap"\]' > /dev/null
 
 # Export local snapshot to S3
+# --no-checksum-verify is needed for HBase 2.6.1 until this is fixed: https://issues.apache.org/jira/browse/HBASE-28998
 export-snapshot-to-s3 \
-        --no-checksum-verify \ # needed for HBase 2.6.1 until this is fixed: https://issues.apache.org/jira/browse/HBASE-28998
+        --no-checksum-verify \
         --snapshot snap \
         --copy-to s3a://hbase/snap \
         --overwrite 2>&1 | \
@@ -25,8 +26,9 @@ hbase shell delete-snapshot.hbase 2>&1 | \
     grep '=> \[\]' > /dev/null
 
 # Import snapshot from S3
+# --no-checksum-verify is needed for HBase 2.6.1 until this is fixed: https://issues.apache.org/jira/browse/HBASE-28998
 export-snapshot-to-s3 \
-        --no-checksum-verify \ # needed for HBase 2.6.1 until this is fixed: https://issues.apache.org/jira/browse/HBASE-28998
+        --no-checksum-verify \
         --snapshot snap \
         --copy-from s3a://hbase/snap \
         --copy-to hdfs://test-hdfs/hbase \

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -2,19 +2,19 @@
 dimensions:
   - name: hbase
     values:
-      - 2.6.0
       - 2.4.18
+      - 2.6.1
       # To use a custom image, add a comma and the full name after the product version
-      # - 2.6.0,oci.stackable.tech/sandbox/hbase:2.6.0-stackable0.0.0-dev
+      # - 2.6.1,oci.stackable.tech/sandbox/hbase:2.6.1-stackable0.0.0-dev
       # - 2.4.18,oci.stackable.tech/sandbox/hbase:2.4.18-stackable0.0.0-dev
   - name: hbase-opa
     values:
-      - 2.6.0
+      - 2.6.1
       # To use a custom image, add a comma and the full name after the product version
-      # - 2.6.0,oci.stackable.tech/sandbox/hbase:2.6.0-stackable0.0.0-dev
+      # - 2.6.1,oci.stackable.tech/sandbox/hbase:2.6.1-stackable0.0.0-dev
   - name: hbase-latest
     values:
-      - 2.6.0
+      - 2.6.1
       # - 2.4.18,oci.stackable.tech/sandbox/hbase:2.4.18-stackable0.0.0-dev
   - name: hdfs
     values:


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/docker-images/issues/972

I had to add the `--no-checksum-verify` flag when exporting snapshots to/from S3, because our `snapshot-export` test was failing for HBase 2.6.1.
From what I see, checksum verification was merged and released with 2.6.1: https://issues.apache.org/jira/browse/HBASE-28625
However, it seems to have problems when comparing snapshots on different filesystems (like HDFS and S3).

https://issues.apache.org/jira/browse/HBASE-28702 was also merged into 2.6.1 and seems to introduce a flag to skip checksum-checks between snapshots when exporting tables. I'm not sure if this flag is supposed to work with snapshot exports as well, at least I could not make it work. Setting `fs.checksum.combine.mode` to `COMPOSITE_CRC` also does not seem to work.

https://issues.apache.org/jira/browse/HBASE-28998 (still open) also mentions that it does not work with `COMPOSITE_CRC` and it specificly mentions problems with HDFS in combination with S3.

So I decided to add the `--no-checksum-verify` flag in our tests when exporting snapshots. From what I understand snapshot checksums where not validated before 2.6.1 either. I don't have too much experience with HBase and thus am not sure if this is really the best solution. Could one of our HBase experts (@razvan @siegfriedweber @lfrancke ?) take a look at this as well? If this solution is fine I would adapt the documentation accordingly.

## Definition of Done Checklist

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
