### PR TITLE
fix: update documentation and test to use 2.6.1

### DIFF
--- a/docs/modules/hbase/examples/getting_started/getting_started.sh
+++ b/docs/modules/hbase/examples/getting_started/getting_started.sh
@@ -135,7 +135,7 @@ version() {
 echo "Check cluster version..."
 cluster_version=$(version | jq -r '.Version')
 
-if [ "$cluster_version" == "2.4.18" ]; then
+if [ "$cluster_version" == "2.6.1" ]; then
   echo "Cluster version: $cluster_version"
 else
   echo "Unexpected version: $cluster_version"

--- a/docs/modules/hbase/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/hbase/examples/getting_started/getting_started.sh.j2
@@ -135,7 +135,7 @@ version() {
 echo "Check cluster version..."
 cluster_version=$(version | jq -r '.Version')
 
-if [ "$cluster_version" == "2.4.18" ]; then
+if [ "$cluster_version" == "2.6.1" ]; then
   echo "Cluster version: $cluster_version"
 else
   echo "Unexpected version: $cluster_version"

--- a/docs/modules/hbase/examples/getting_started/hbase.yaml
+++ b/docs/modules/hbase/examples/getting_started/hbase.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-hbase
 spec:
   image:
-    productVersion: 2.4.18
+    productVersion: 2.6.1
   clusterConfig:
     hdfsConfigMapName: simple-hdfs
     zookeeperConfigMapName: simple-hbase-znode

--- a/docs/modules/hbase/examples/getting_started/hbase.yaml.j2
+++ b/docs/modules/hbase/examples/getting_started/hbase.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: simple-hbase
 spec:
   image:
-    productVersion: 2.4.18
+    productVersion: 2.6.1
   clusterConfig:
     hdfsConfigMapName: simple-hdfs
     zookeeperConfigMapName: simple-hbase-znode

--- a/docs/modules/hbase/examples/usage-guide/hbck2-job.yaml
+++ b/docs/modules/hbase/examples/usage-guide/hbck2-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: hbck2
-        image: oci.stackable.tech/sdp/hbase:2.4.18-stackable0.0.0-dev
+        image: oci.stackable.tech/sdp/hbase:2.6.1-stackable0.0.0-dev
         volumeMounts:
         - name: hbase-config
           mountPath: /stackable/conf

--- a/docs/modules/hbase/examples/usage-guide/hbck2-job.yaml.j2
+++ b/docs/modules/hbase/examples/usage-guide/hbck2-job.yaml.j2
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: hbck2
-        image: oci.stackable.tech/sdp/hbase:2.4.18-stackable{{ versions.hbase }}
+        image: oci.stackable.tech/sdp/hbase:2.6.1-stackable{{ versions.hbase }}
         volumeMounts:
         - name: hbase-config
           mountPath: /stackable/conf

--- a/docs/modules/hbase/examples/usage-guide/snapshot-export-job.yaml
+++ b/docs/modules/hbase/examples/usage-guide/snapshot-export-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: hbase
-        image: oci.stackable.tech/sdp/hbase:2.4.18-stackable0.0.0-dev
+        image: oci.stackable.tech/sdp/hbase:2.6.1-stackable0.0.0-dev
         volumeMounts:
         - name: hbase-config
           mountPath: /stackable/conf
@@ -40,6 +40,7 @@ spec:
         - my-snapshot
         - --copy-to
         - s3a://hbase/my-snapshot
+        - --no-checksum-verify
       volumes:
       - name: hbase-config
         projected:

--- a/docs/modules/hbase/examples/usage-guide/snapshot-export-job.yaml.j2
+++ b/docs/modules/hbase/examples/usage-guide/snapshot-export-job.yaml.j2
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: hbase
-        image: oci.stackable.tech/sdp/hbase:2.4.18-stackable{{ versions.hbase }}
+        image: oci.stackable.tech/sdp/hbase:2.6.1-stackable{{ versions.hbase }}
         volumeMounts:
         - name: hbase-config
           mountPath: /stackable/conf
@@ -40,6 +40,7 @@ spec:
         - my-snapshot
         - --copy-to
         - s3a://hbase/my-snapshot
+        - --no-checksum-verify
       volumes:
       - name: hbase-config
         projected:

--- a/docs/modules/hbase/pages/getting_started/first_steps.adoc
+++ b/docs/modules/hbase/pages/getting_started/first_steps.adoc
@@ -85,7 +85,7 @@ include::example$getting_started/getting_started.sh[tag=cluster-version]
 This returns the version that was specified in the HBase cluster definition:
 
 [source,json]
-{"Version":"2.4.18"}
+{"Version":"2.6.1"}
 
 The cluster status can be checked and formatted like this:
 

--- a/docs/modules/hbase/pages/usage-guide/snapshot-export.adoc
+++ b/docs/modules/hbase/pages/usage-guide/snapshot-export.adoc
@@ -33,6 +33,7 @@ $ export \
     AWS_SSL_ENABLED=true \
     AWS_PATH_STYLE_ACCESS=true
 $ export-snapshot-to-s3 \
+    --no-checksum-verify \
     --snapshot my-snapshot \
     --copy-to s3a://my-bucket/my-snapshot
 ----
@@ -42,6 +43,7 @@ Snapshots can also be imported from S3 into HDFS:
 [source,shell]
 ----
 $ export-snapshot-to-s3 \
+    --no-checksum-verify \
     --snapshot snap \
     --copy-from s3a://my-bucket/my-snapshot \
     --copy-to hdfs://simple-hdfs/hbase

--- a/rust/crd/src/affinity.rs
+++ b/rust/crd/src/affinity.rs
@@ -105,7 +105,7 @@ mod tests {
           name: simple-hbase
         spec:
           image:
-            productVersion: 2.4.18
+            productVersion: 2.6.1
           clusterConfig:
             hdfsConfigMapName: simple-hdfs
             zookeeperConfigMapName: simple-znode

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -1262,7 +1262,7 @@ metadata:
   name: test-hbase
 spec:
   image:
-    productVersion: 2.4.18
+    productVersion: 2.6.1
   clusterConfig:
     hdfsConfigMapName: test-hdfs
     zookeeperConfigMapName: test-znode
@@ -1310,7 +1310,7 @@ spec:
         )]);
 
         let validated_config = validate_all_roles_and_groups_config(
-            "2.4.18",
+            "2.6.1",
             &transform_all_roles_to_config(&hbase, roles).unwrap(),
             &ProductConfigManager::from_yaml_file("../../deploy/config-spec/properties.yaml")
                 .unwrap(),
@@ -1363,7 +1363,7 @@ metadata:
   name: test-hbase
 spec:
   image:
-    productVersion: 2.4.18
+    productVersion: 2.6.1
   clusterConfig:
     hdfsConfigMapName: test-hdfs
     zookeeperConfigMapName: test-znode

--- a/rust/operator-binary/src/config/jvm.rs
+++ b/rust/operator-binary/src/config/jvm.rs
@@ -198,7 +198,7 @@ mod tests {
           name: simple-hbase
         spec:
           image:
-            productVersion: 2.4.18
+            productVersion: 2.6.1
           clusterConfig:
             hdfsConfigMapName: simple-hdfs
             zookeeperConfigMapName: simple-znode
@@ -250,7 +250,6 @@ mod tests {
         assert_eq!(
             role_specific_non_heap_jvm_args,
             "-Djava.security.properties=/stackable/conf/security.properties \
-            -javaagent:/stackable/jmx/jmx_prometheus_javaagent.jar=9100:/stackable/jmx/regionserver.yaml \
             -Djava.security.krb5.conf=/stackable/kerberos/krb5.conf \
             -Dhttps.proxyHost=proxy.my.corp \
             -Djava.net.preferIPv4Stack=true \

--- a/rust/operator-binary/src/hbase_controller.rs
+++ b/rust/operator-binary/src/hbase_controller.rs
@@ -1199,9 +1199,9 @@ mod test {
     use super::*;
 
     #[rstest]
-    #[case("2.6.0", HbaseRole::Master, vec!["master", "ui-http"])]
-    #[case("2.6.0", HbaseRole::RegionServer, vec!["regionserver", "ui-http"])]
-    #[case("2.6.0", HbaseRole::RestServer, vec!["rest-http", "ui-http"])]
+    #[case("2.6.1", HbaseRole::Master, vec!["master", "ui-http"])]
+    #[case("2.6.1", HbaseRole::RegionServer, vec!["regionserver", "ui-http"])]
+    #[case("2.6.1", HbaseRole::RestServer, vec!["rest-http", "ui-http"])]
     #[case("2.4.14", HbaseRole::Master, vec!["master", "ui-http", "metrics"])]
     #[case("2.4.14", HbaseRole::RegionServer, vec!["regionserver", "ui-http", "metrics"])]
     #[case("2.4.14", HbaseRole::RestServer, vec!["rest-http", "ui-http", "metrics"])]


### PR DESCRIPTION
# Description

I forgot to update tests and docs to the latest HBase version in https://github.com/stackabletech/hbase-operator/pull/627

I removed the line with `jmx_prometheus_javaagent.jar` in the `test_construct_jvm_argument_overrides` test since the JMX exporter is not needed for HBase 2.6 and the test would fail otherwise.

## Definition of Done Checklist

```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
