### PR TITLE
test: Remove HDFS 3.3.4, 3.3.6, 3.4.0

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -18,9 +18,6 @@ dimensions:
       # - 2.4.18,oci.stackable.tech/sandbox/hbase:2.4.18-stackable0.0.0-dev
   - name: hdfs
     values:
-      - 3.3.4
-      - 3.3.6
-      - 3.4.0
       - 3.4.1
   - name: hdfs-latest
     values:


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1077.

- Remove HDFS `3.3.4`, `3.3.6`, `3.4.0` from tests

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

# Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible

# Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

# Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
