### PR TITLE
chore: Remove hardcoded uid and gid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - BREAKING: Inject the vector aggregator address into the vector config using the env var `VECTOR_AGGREGATOR_ADDRESS` instead
     of having the operator write it to the vector config ([#645]).
 - test: Bump to Vector `0.46.1` ([#657]).
+- Previously this operator would hardcode the UID and GID of the Pods being created to 1000/0, this has changed now ([#660])
+  - The defaults from the docker images itself will now apply, which will be different from 1000/0 going forward
 
 ### Fixed
 
@@ -39,6 +41,7 @@
 [#654]: https://github.com/stackabletech/hbase-operator/pull/654
 [#655]: https://github.com/stackabletech/hbase-operator/pull/655
 [#657]: https://github.com/stackabletech/hbase-operator/pull/657
+[#660]: https://github.com/stackabletech/hbase-operator/pull/660
 
 ## [25.3.0] - 2025-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   - The `runAsUser` and `runAsGroup` fields will not be set anymore by the operator
   - The defaults from the docker images itself will now apply, which will be different from 1000/0 going forward
   - This is marked as breaking because tools and policies might exist, which require these fields to be set
+
 ### Fixed
 
 - Use `json` file extension for log files ([#647]).

--- a/rust/operator-binary/src/hbase_controller.rs
+++ b/rust/operator-binary/src/hbase_controller.rs
@@ -101,7 +101,6 @@ const HBASE_CONFIG_TMP_DIR: &str = "/stackable/tmp/hbase";
 const HBASE_LOG_CONFIG_TMP_DIR: &str = "/stackable/tmp/log_config";
 
 const DOCKER_IMAGE_BASE_NAME: &str = "hbase";
-const HBASE_UID: i64 = 1000;
 
 pub struct Ctx {
     pub client: stackable_operator::client::Client,
@@ -939,13 +938,7 @@ fn build_rolegroup_statefulset(
         )
         .context(AddVolumeSnafu)?
         .service_account_name(service_account.name_any())
-        .security_context(
-            PodSecurityContextBuilder::new()
-                .run_as_user(HBASE_UID)
-                .run_as_group(0)
-                .fs_group(1000)
-                .build(),
-        );
+        .security_context(PodSecurityContextBuilder::new().fs_group(1000).build());
 
     if let Some(ContainerLogConfig {
         choice:


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/651

Remove hardcoded uid and gid, they'll default to the ones from the docker images now.
For 25.7 that means they might change from 1000/0
See https://github.com/stackabletech/docker-images/pull/916 for details

## Definition of Done Checklist

### Author

- [x] Changes are OpenShift compatible
- [x] Integration tests passed (for non trivial changes)

### Reviewer

- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Changelog updated

### Acceptance

- [ ] Proper release label has been added
