### PR TITLE
fix: Update security entries for Pods

### DIFF
--- a/tests/templates/kuttl/kerberos/20-access-hdfs.yaml.j2
+++ b/tests/templates/kuttl/kerberos/20-access-hdfs.yaml.j2
@@ -64,7 +64,5 @@ commands:
                           storage: "1"
             securityContext:
               fsGroup: 1000
-              runAsGroup: 1000
-              runAsUser: 1000
             restartPolicy: OnFailure
       EOF

--- a/tests/templates/kuttl/kerberos/41-access-hbase.yaml.j2
+++ b/tests/templates/kuttl/kerberos/41-access-hbase.yaml.j2
@@ -75,8 +75,6 @@ commands:
                           storage: "1"
             securityContext:
               fsGroup: 1000
-              runAsGroup: 1000
-              runAsUser: 1000
             restartPolicy: OnFailure
       EOF
 ---

--- a/tests/templates/kuttl/opa/41-access-hbase.yaml.j2
+++ b/tests/templates/kuttl/opa/41-access-hbase.yaml.j2
@@ -74,8 +74,6 @@ commands:
                           storage: "1"
             securityContext:
               fsGroup: 1000
-              runAsGroup: 1000
-              runAsUser: 1000
             restartPolicy: OnFailure
       EOF
 ---

--- a/tests/templates/kuttl/snapshot-export/31_test-snapshot-export-job.yaml
+++ b/tests/templates/kuttl/snapshot-export/31_test-snapshot-export-job.yaml
@@ -45,7 +45,5 @@ spec:
                   name: test-hdfs
       securityContext:
         fsGroup: 1000
-        runAsGroup: 1000
-        runAsUser: 1000
       serviceAccountName: test-sa
       restartPolicy: OnFailure


### PR DESCRIPTION
## Description

Local tests:

```
--- PASS: kuttl (1894.71s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/snapshot-export_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.3_openshift-false (237.33s)
        --- PASS: kuttl/harness/kerberos_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.3_krb5-1.21.1_listener-class-cluster-internal_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (494.99s)
        --- PASS: kuttl/harness/smoke_hbase-2.6.2_hdfs-3.4.1_zookeeper-3.9.3_listener-class-external-unstable_openshift-false (274.42s)
        --- PASS: kuttl/harness/smoke_hbase-2.6.2_hdfs-3.4.1_zookeeper-3.9.3_listener-class-cluster-internal_openshift-false (232.76s)
        --- PASS: kuttl/harness/opa_hbase-opa-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.3_krb5-1.21.1_opa-1.4.2_openshift-false (250.91s)
        --- PASS: kuttl/harness/orphaned_resources_hbase-latest-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.3_openshift-false (139.52s)
        --- PASS: kuttl/harness/profiling_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.3_openshift-false (165.50s)
        --- PASS: kuttl/harness/logging_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.3_openshift-false (193.05s)
        --- PASS: kuttl/harness/cluster-operation_hbase-latest-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.3_openshift-false (196.90s)
        --- PASS: kuttl/harness/overrides_hbase-latest-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.3_openshift-false (144.92s)
        --- PASS: kuttl/harness/omid_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.3_openshift-false_omid-1.1.3 (259.28s)
        --- PASS: kuttl/harness/external-access_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.3_openshift-false (166.06s)
        --- PASS: kuttl/harness/shutdown_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.3_openshift-false (285.25s)
        --- PASS: kuttl/harness/resources_hbase-latest-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.3_openshift-false (172.30s)
        --- PASS: kuttl/harness/kerberos_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.3_krb5-1.21.1_listener-class-external-unstable_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (289.52s)
PASS
```


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
