### PR TITLE
fix(docs): Update getting-started script pre-25.7.0

### DIFF
--- a/docs/modules/hbase/examples/getting_started/getting_started.sh
+++ b/docs/modules/hbase/examples/getting_started/getting_started.sh
@@ -122,14 +122,14 @@ kubectl rollout status --watch statefulset/simple-hbase-restserver-default --tim
 version() {
   # tag::cluster-version[]
   kubectl exec -n default simple-hbase-restserver-default-0 -- \
-  curl -s -XGET -H "Accept: application/json" "http://simple-hbase-restserver-default:8080/version/cluster"
+  curl -s -XGET -H "Accept: application/json" "http://simple-hbase-restserver-default-headless:8080/version/cluster"
   # end::cluster-version[]
 }
 
 echo "Check cluster version..."
 cluster_version=$(version | jq -r '.Version')
 
-if [ "$cluster_version" == "2.6.2" ]; then
+if [ "$cluster_version" == "2.6.2-stackable0.0.0-dev" ]; then
   echo "Cluster version: $cluster_version"
 else
   echo "Unexpected version: $cluster_version"
@@ -139,26 +139,26 @@ fi
 echo "Check cluster status..."
 # tag::cluster-status[]
 kubectl exec -n default simple-hbase-restserver-default-0 \
--- curl -s -XGET -H "Accept: application/json" "http://simple-hbase-restserver-default:8080/status/cluster" | json_pp
+-- curl -s -XGET -H "Accept: application/json" "http://simple-hbase-restserver-default-headless:8080/status/cluster" | json_pp
 # end::cluster-status[]
 
 echo "Check table via REST API..."
 # tag::create-table[]
 kubectl exec -n default simple-hbase-restserver-default-0 \
 -- curl -s -XPUT -H "Accept: text/xml" -H "Content-Type: text/xml" \
-"http://simple-hbase-restserver-default:8080/users/schema" \
+"http://simple-hbase-restserver-default-headless:8080/users/schema" \
 -d '<TableSchema name="users"><ColumnSchema name="cf" /></TableSchema>'
 # end::create-table[]
 
 # tag::get-table[]
 kubectl exec -n default simple-hbase-restserver-default-0 \
--- curl -s -XGET -H "Accept: application/json" "http://simple-hbase-restserver-default:8080/users/schema" | json_pp
+-- curl -s -XGET -H "Accept: application/json" "http://simple-hbase-restserver-default-headless:8080/users/schema" | json_pp
 # end::get-table[]
 
 get_all() {
   # tag::get-tables[]
   kubectl exec -n default simple-hbase-restserver-default-0 \
-  -- curl -s -XGET -H "Accept: application/json" "http://simple-hbase-restserver-default:8080/" |  json_pp
+  -- curl -s -XGET -H "Accept: application/json" "http://simple-hbase-restserver-default-headless:8080/" |  json_pp
   # end::get-tables[]
 }
 

--- a/docs/modules/hbase/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/hbase/examples/getting_started/getting_started.sh.j2
@@ -122,14 +122,14 @@ kubectl rollout status --watch statefulset/simple-hbase-restserver-default --tim
 version() {
   # tag::cluster-version[]
   kubectl exec -n default simple-hbase-restserver-default-0 -- \
-  curl -s -XGET -H "Accept: application/json" "http://simple-hbase-restserver-default:8080/version/cluster"
+  curl -s -XGET -H "Accept: application/json" "http://simple-hbase-restserver-default-headless:8080/version/cluster"
   # end::cluster-version[]
 }
 
 echo "Check cluster version..."
 cluster_version=$(version | jq -r '.Version')
 
-if [ "$cluster_version" == "2.6.2" ]; then
+if [ "$cluster_version" == "2.6.2-stackable0.0.0-dev" ]; then
   echo "Cluster version: $cluster_version"
 else
   echo "Unexpected version: $cluster_version"
@@ -139,26 +139,26 @@ fi
 echo "Check cluster status..."
 # tag::cluster-status[]
 kubectl exec -n default simple-hbase-restserver-default-0 \
--- curl -s -XGET -H "Accept: application/json" "http://simple-hbase-restserver-default:8080/status/cluster" | json_pp
+-- curl -s -XGET -H "Accept: application/json" "http://simple-hbase-restserver-default-headless:8080/status/cluster" | json_pp
 # end::cluster-status[]
 
 echo "Check table via REST API..."
 # tag::create-table[]
 kubectl exec -n default simple-hbase-restserver-default-0 \
 -- curl -s -XPUT -H "Accept: text/xml" -H "Content-Type: text/xml" \
-"http://simple-hbase-restserver-default:8080/users/schema" \
+"http://simple-hbase-restserver-default-headless:8080/users/schema" \
 -d '<TableSchema name="users"><ColumnSchema name="cf" /></TableSchema>'
 # end::create-table[]
 
 # tag::get-table[]
 kubectl exec -n default simple-hbase-restserver-default-0 \
--- curl -s -XGET -H "Accept: application/json" "http://simple-hbase-restserver-default:8080/users/schema" | json_pp
+-- curl -s -XGET -H "Accept: application/json" "http://simple-hbase-restserver-default-headless:8080/users/schema" | json_pp
 # end::get-table[]
 
 get_all() {
   # tag::get-tables[]
   kubectl exec -n default simple-hbase-restserver-default-0 \
-  -- curl -s -XGET -H "Accept: application/json" "http://simple-hbase-restserver-default:8080/" |  json_pp
+  -- curl -s -XGET -H "Accept: application/json" "http://simple-hbase-restserver-default-headless:8080/" |  json_pp
   # end::get-tables[]
 }
 

--- a/docs/modules/hbase/pages/getting_started/first_steps.adoc
+++ b/docs/modules/hbase/pages/getting_started/first_steps.adoc
@@ -102,31 +102,45 @@ which displays cluster metadata that looks like this (only the first region is i
          "Region" : [
             {
                "currentCompactedKVs" : 0,
-               "memStoreSizeMB" : 0,
-               "name" : "U1lTVEVNLkNBVEFMT0csLDE2NjExNjA0NDM2NjcuYmYwMzA1YmM4ZjFmOGIwZWMwYjhmMGNjMWI5N2RmMmUu",
-               "readRequestsCount" : 104,
-               "rootIndexSizeKB" : 1,
-               "storefileIndexSizeKB" : 1,
-               "storefileSizeMB" : 1,
-               "storefiles" : 1,
+               "memStoreSizeMB" : 1,
+               "name" : "aGJhc2U6bWV0YSwsMQ==",
+               "readRequestsCount" : 4,
+               "rootIndexSizeKB" : 0,
+               "storefileIndexSizeKB" : 0,
+               "storefileSizeMB" : 0,
+               "storefiles" : 0,
+               "stores" : 3,
+               "totalCompactingKVs" : 0,
+               "totalStaticBloomSizeKB" : 0,
+               "totalStaticIndexSizeKB" : 0,
+               "writeRequestsCount" : 5
+            },
+            {
+               "currentCompactedKVs" : 0,
+               "memStoreSizeMB" : 1,
+               "name" : "aGJhc2U6bmFtZXNwYWNlLCwxNzUyNDk0MTQzMDQ0LjA1MTA1NWM1NzhhMDQyOWJmZTIwZTFkYTBiY2M4MWE3Lg==",
+               "readRequestsCount" : 6,
+               "rootIndexSizeKB" : 0,
+               "storefileIndexSizeKB" : 0,
+               "storefileSizeMB" : 0,
+               "storefiles" : 0,
                "stores" : 1,
                "totalCompactingKVs" : 0,
                "totalStaticBloomSizeKB" : 0,
-               "totalStaticIndexSizeKB" : 1,
-               "writeRequestsCount" : 360
-            },
-            ...
+               "totalStaticIndexSizeKB" : 0,
+               "writeRequestsCount" : 2
+            }
          ],
-         "heapSizeMB" : 351,
-         "maxHeapSizeMB" : 11978,
-         "name" : "simple-hbase-regionserver-default-0.simple-hbase-regionserver-default.default.svc.cluster.local:16020",
-         "requests" : 395,
-         "startCode" : 1661156787704
+         "heapSizeMB" : 108,
+         "maxHeapSizeMB" : 2458,
+         "name" : "simple-hbase-regionserver-default-0-listener.default.svc.cluster.local:16020",
+         "requests" : 16,
+         "startCode" : 1752494125463
       }
    ],
-   "averageLoad" : 43,
-   "regions" : 43,
-   "requests" : 1716
+   "averageLoad" : 2,
+   "regions" : 2,
+   "requests" : 17
 }
 
 You can now create a table like this:


### PR DESCRIPTION
## Check and Update Getting Started Script

<!--
    Make sure to update the link in 'issues/.github/ISSUE_TEMPLATE/pre-release-getting-started-scripts.md'
    when you rename this file.
-->

<!--
    Replace 'TRACKING_ISSUE' with the applicable release tracking issue number.
-->

Part of <https://github.com/stackabletech/issues/issues/TRACKING_ISSUE>

> [!NOTE]
> During a Stackable release we need to check (and optionally update) the
> getting-started scripts to ensure they still work after product and operator
> updates.

```shell
# Some of the scripts are in a code/ subdirectory
# pushd docs/modules/superset/examples/getting_started
# pushd docs/modules/superset/examples/getting_started/code
pushd $(fd -td getting_started | grep examples); cd code 2>/dev/null || true

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh stackablectl

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh helm

popd
```
