### PR TITLE
fix: Add RBAC permission to patch events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
   - The default Kubernetes cluster domain name is now fetched from the kubelet API unless explicitly configured.
   - This requires operators to have the RBAC permission to get nodes/proxy in the apiGroup "". The helm-chart takes care of this.
   - The CLI argument `--kubernetes-node-name` or env variable `KUBERNETES_NODE_NAME` needs to be set. The helm-chart takes care of this.
+- The operator helm-chart now grants RBAC `patch` permissions on `events.k8s.io/events`,
+  so events can be aggregated (e.g. "error happened 10 times over the last 5 minutes") ([#678]).
 
 ### Fixed
 
@@ -62,6 +64,7 @@
 [#661]: https://github.com/stackabletech/hbase-operator/pull/661
 [#672]: https://github.com/stackabletech/hbase-operator/pull/672
 [#675]: https://github.com/stackabletech/hbase-operator/pull/675
+[#678]: https://github.com/stackabletech/hbase-operator/pull/678
 
 ## [25.3.0] - 2025-03-21
 

--- a/deploy/helm/hbase-operator/templates/roles.yaml
+++ b/deploy/helm/hbase-operator/templates/roles.yaml
@@ -135,6 +135,7 @@ rules:
       - events
     verbs:
       - create
+      - patch
 {{ if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
   - apiGroups:
       - security.openshift.io


### PR DESCRIPTION
Needed since https://github.com/stackabletech/operator-rs/pull/938

Not 100% sure why the product needs this, but it was this way before.
