### PR TITLE
docs: Fix supported versions (cherry-pick)

### DIFF
--- a/docs/modules/hbase/partials/supported-versions.adoc
+++ b/docs/modules/hbase/partials/supported-versions.adoc
@@ -2,5 +2,5 @@
 // This is a separate file, since it is used by both the direct HBase-Operator documentation, and the overarching
 // Stackable Platform documentation.
 
-- 2.6.1 (LTS)
-- 2.6.2
+- 2.6.2 (LTS)
+- 2.6.1 (Deprecated)


### PR DESCRIPTION
Apache HBase 2.6.2 is the LTS version and 2.6.1 was deprecated in SDP 25.7.0. This is cherry-picked from e3ad7c0 (#684).