### PR TITLE
chore: bump HBase to 2.6.3 prior to 25.11

### DIFF
--- a/docs/modules/hbase/examples/getting_started/getting_started.sh
+++ b/docs/modules/hbase/examples/getting_started/getting_started.sh
@@ -129,7 +129,7 @@ version() {
 echo "Check cluster version..."
 cluster_version=$(version | jq -r '.Version')
 
-if [ "$cluster_version" == "2.6.2-stackable0.0.0-dev" ]; then
+if [ "$cluster_version" == "2.6.3-stackable0.0.0-dev" ]; then
   echo "Cluster version: $cluster_version"
 else
   echo "Unexpected version: $cluster_version"

--- a/docs/modules/hbase/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/hbase/examples/getting_started/getting_started.sh.j2
@@ -129,7 +129,7 @@ version() {
 echo "Check cluster version..."
 cluster_version=$(version | jq -r '.Version')
 
-if [ "$cluster_version" == "2.6.2-stackable0.0.0-dev" ]; then
+if [ "$cluster_version" == "2.6.3-stackable0.0.0-dev" ]; then
   echo "Cluster version: $cluster_version"
 else
   echo "Unexpected version: $cluster_version"

--- a/docs/modules/hbase/examples/getting_started/hbase.yaml
+++ b/docs/modules/hbase/examples/getting_started/hbase.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-hbase
 spec:
   image:
-    productVersion: 2.6.2
+    productVersion: 2.6.3
   clusterConfig:
     hdfsConfigMapName: simple-hdfs
     zookeeperConfigMapName: simple-hbase-znode

--- a/docs/modules/hbase/examples/getting_started/hbase.yaml.j2
+++ b/docs/modules/hbase/examples/getting_started/hbase.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: simple-hbase
 spec:
   image:
-    productVersion: 2.6.2
+    productVersion: 2.6.3
   clusterConfig:
     hdfsConfigMapName: simple-hdfs
     zookeeperConfigMapName: simple-hbase-znode

--- a/docs/modules/hbase/examples/getting_started/hdfs.yaml
+++ b/docs/modules/hbase/examples/getting_started/hdfs.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-hdfs
 spec:
   image:
-    productVersion: 3.4.1
+    productVersion: 3.4.2
   clusterConfig:
     dfsReplication: 1
     zookeeperConfigMapName: simple-hdfs-znode

--- a/docs/modules/hbase/examples/getting_started/hdfs.yaml.j2
+++ b/docs/modules/hbase/examples/getting_started/hdfs.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: simple-hdfs
 spec:
   image:
-    productVersion: 3.4.1
+    productVersion: 3.4.2
   clusterConfig:
     dfsReplication: 1
     zookeeperConfigMapName: simple-hdfs-znode

--- a/docs/modules/hbase/examples/usage-guide/hbck2-job.yaml
+++ b/docs/modules/hbase/examples/usage-guide/hbck2-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: hbck2
-        image: oci.stackable.tech/sdp/hbase:2.6.2-stackable0.0.0-dev
+        image: oci.stackable.tech/sdp/hbase:2.6.3-stackable0.0.0-dev
         volumeMounts:
         - name: hbase-config
           mountPath: /stackable/conf

--- a/docs/modules/hbase/examples/usage-guide/hbck2-job.yaml.j2
+++ b/docs/modules/hbase/examples/usage-guide/hbck2-job.yaml.j2
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: hbck2
-        image: oci.stackable.tech/sdp/hbase:2.6.2-stackable{{ versions.hbase }}
+        image: oci.stackable.tech/sdp/hbase:2.6.3-stackable{{ versions.hbase }}
         volumeMounts:
         - name: hbase-config
           mountPath: /stackable/conf

--- a/docs/modules/hbase/examples/usage-guide/snapshot-export-job.yaml
+++ b/docs/modules/hbase/examples/usage-guide/snapshot-export-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: hbase
-        image: oci.stackable.tech/sdp/hbase:2.6.2-stackable0.0.0-dev
+        image: oci.stackable.tech/sdp/hbase:2.6.3-stackable0.0.0-dev
         volumeMounts:
         - name: hbase-config
           mountPath: /stackable/conf

--- a/docs/modules/hbase/examples/usage-guide/snapshot-export-job.yaml.j2
+++ b/docs/modules/hbase/examples/usage-guide/snapshot-export-job.yaml.j2
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: hbase
-        image: oci.stackable.tech/sdp/hbase:2.6.2-stackable{{ versions.hbase }}
+        image: oci.stackable.tech/sdp/hbase:2.6.3-stackable{{ versions.hbase }}
         volumeMounts:
         - name: hbase-config
           mountPath: /stackable/conf

--- a/docs/modules/hbase/pages/getting_started/first_steps.adoc
+++ b/docs/modules/hbase/pages/getting_started/first_steps.adoc
@@ -85,7 +85,7 @@ include::example$getting_started/getting_started.sh[tag=cluster-version]
 This returns the version that was specified in the HBase cluster definition:
 
 [source,json]
-{"Version":"2.6.2"}
+{"Version":"2.6.3"}
 
 The cluster status can be checked and formatted like this:
 

--- a/docs/modules/hbase/partials/supported-versions.adoc
+++ b/docs/modules/hbase/partials/supported-versions.adoc
@@ -2,5 +2,5 @@
 // This is a separate file, since it is used by both the direct HBase-Operator documentation, and the overarching
 // Stackable Platform documentation.
 
-- 2.6.2 (LTS)
-- 2.6.1 (Deprecated)
+- 2.6.3 (LTS)
+- 2.6.2 (Deprecated)

--- a/rust/operator-binary/src/config/jvm.rs
+++ b/rust/operator-binary/src/config/jvm.rs
@@ -147,7 +147,7 @@ mod tests {
           name: simple-hbase
         spec:
           image:
-            productVersion: 2.6.2
+            productVersion: 2.6.3
           clusterConfig:
             hdfsConfigMapName: simple-hdfs
             zookeeperConfigMapName: simple-znode
@@ -184,7 +184,7 @@ mod tests {
           name: simple-hbase
         spec:
           image:
-            productVersion: 2.6.2
+            productVersion: 2.6.3
           clusterConfig:
             hdfsConfigMapName: simple-hdfs
             zookeeperConfigMapName: simple-znode

--- a/rust/operator-binary/src/crd/affinity.rs
+++ b/rust/operator-binary/src/crd/affinity.rs
@@ -105,7 +105,7 @@ mod tests {
           name: simple-hbase
         spec:
           image:
-            productVersion: 2.6.2
+            productVersion: 2.6.3
           clusterConfig:
             hdfsConfigMapName: simple-hdfs
             zookeeperConfigMapName: simple-znode

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -1311,7 +1311,7 @@ metadata:
   name: test-hbase
 spec:
   image:
-    productVersion: 2.6.2
+    productVersion: 2.6.3
   clusterConfig:
     hdfsConfigMapName: test-hdfs
     zookeeperConfigMapName: test-znode
@@ -1359,7 +1359,7 @@ spec:
         )]);
 
         let validated_config = validate_all_roles_and_groups_config(
-            "2.6.2",
+            "2.6.3",
             &transform_all_roles_to_config(&hbase, roles).unwrap(),
             &ProductConfigManager::from_yaml_file("../../deploy/config-spec/properties.yaml")
                 .unwrap(),
@@ -1412,7 +1412,7 @@ metadata:
   name: test-hbase
 spec:
   image:
-    productVersion: 2.6.2
+    productVersion: 2.6.3
   clusterConfig:
     hdfsConfigMapName: test-hdfs
     zookeeperConfigMapName: test-znode

--- a/rust/operator-binary/src/hbase_controller.rs
+++ b/rust/operator-binary/src/hbase_controller.rs
@@ -1210,12 +1210,12 @@ mod test {
     use super::*;
 
     #[rstest]
-    #[case("2.6.1", HbaseRole::Master, vec!["master", "ui-http"])]
-    #[case("2.6.1", HbaseRole::RegionServer, vec!["regionserver", "ui-http"])]
-    #[case("2.6.1", HbaseRole::RestServer, vec!["rest-http", "ui-http"])]
     #[case("2.6.2", HbaseRole::Master, vec!["master", "ui-http"])]
     #[case("2.6.2", HbaseRole::RegionServer, vec!["regionserver", "ui-http"])]
     #[case("2.6.2", HbaseRole::RestServer, vec!["rest-http", "ui-http"])]
+    #[case("2.6.3", HbaseRole::Master, vec!["master", "ui-http"])]
+    #[case("2.6.3", HbaseRole::RegionServer, vec!["regionserver", "ui-http"])]
+    #[case("2.6.3", HbaseRole::RestServer, vec!["rest-http", "ui-http"])]
     fn test_rolegroup_service_ports(
         #[case] hbase_version: &str,
         #[case] role: HbaseRole,

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -2,25 +2,25 @@
 dimensions:
   - name: hbase
     values:
-      - 2.6.1
       - 2.6.2
+      - 2.6.3
       # To use a custom image, add a comma and the full name after the product version
-      # - 2.6.2,oci.stackable.tech/sandbox/hbase:2.6.2-stackable0.0.0-dev
+      # - 2.6.3,oci.stackable.tech/sandbox/hbase:2.6.3-stackable0.0.0-dev
   - name: hbase-opa
     values:
-      - 2.6.2
+      - 2.6.3
       # To use a custom image, add a comma and the full name after the product version
-      # - 2.6.2,oci.stackable.tech/sandbox/hbase:2.6.2-stackable0.0.0-dev
+      # - 2.6.3,oci.stackable.tech/sandbox/hbase:2.6.3-stackable0.0.0-dev
   - name: hbase-latest
     values:
-      - 2.6.2
-      # - 2.4.18,oci.stackable.tech/sandbox/hbase:2.4.18-stackable0.0.0-dev
+      - 2.6.3
+      # - 2.6.3,oci.stackable.tech/sandbox/hbase:2.6.3-stackable0.0.0-dev
   - name: hdfs
     values:
-      - 3.4.1
+      - 3.4.2
   - name: hdfs-latest
     values:
-      - 3.4.1
+      - 3.4.2
   - name: zookeeper
     values:
       - 3.9.3


### PR DESCRIPTION
## Description

Tested with custom-built image:
- :green_circle: getting-started scripts
- :hourglass_flowing_sand: integration tests

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
