### PR TITLE
chore: Bump zookeeper version for 25.11.0

### DIFF
--- a/docs/modules/hbase/examples/getting_started/zk.yaml
+++ b/docs/modules/hbase/examples/getting_started/zk.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.3
+    productVersion: 3.9.4
   servers:
     roleGroups:
       default:

--- a/docs/modules/hbase/examples/getting_started/zk.yaml.j2
+++ b/docs/modules/hbase/examples/getting_started/zk.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.3
+    productVersion: 3.9.4
   servers:
     roleGroups:
       default:

--- a/tests/templates/kuttl/snapshot-export/10_helm-bitnami-minio-values.yaml.j2
+++ b/tests/templates/kuttl/snapshot-export/10_helm-bitnami-minio-values.yaml.j2
@@ -1,4 +1,25 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 14.9.0 if modifying images
+
+image:
+  repository: bitnamilegacy/minio
+clientImage:
+  repository: bitnamilegacy/minio-client
+defaultInitContainers:
+  volumePermissions:  # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    image:
+      repository: bitnamilegacy/os-shell
+console:
+  image:
+    repository: bitnamilegacy/minio-object-browser
+
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
+volumePermissions:
+  image:
+    repository: bitnamilegacy/os-shell
+
 persistence:
   enabled: false # "false" means, that an emptyDir is used instead of a persistentVolumeClaim
   size: 64Mi

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -24,9 +24,10 @@ dimensions:
   - name: zookeeper
     values:
       - 3.9.3
+      - 3.9.4
   - name: zookeeper-latest
     values:
-      - 3.9.3
+      - 3.9.4
   - name: krb5
     values:
       - 1.21.1


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/docker-images/issues/1275

### Integrationtests

```
--- FAIL: kuttl (6923.92s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/resources_hbase-latest-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (183.82s)
        --- PASS: kuttl/harness/overrides_hbase-latest-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (246.90s)
        --- PASS: kuttl/harness/orphaned_resources_hbase-latest-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (198.73s)
        --- PASS: kuttl/harness/opa_hbase-opa-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_krb5-1.21.1_opa-1.8.0_openshift-false (329.23s)
        --- PASS: kuttl/harness/smoke_hbase-2.6.1_hdfs-3.4.1_zookeeper-3.9.3_listener-class-external-unstable_openshift-false (321.09s)
        --- PASS: kuttl/harness/smoke_hbase-2.6.2_hdfs-3.4.1_zookeeper-3.9.4_listener-class-external-unstable_openshift-false (427.70s)
        --- FAIL: kuttl/harness/smoke_hbase-2.6.2_hdfs-3.4.1_zookeeper-3.9.4_listener-class-cluster-internal_openshift-false (554.07s)
        --- FAIL: kuttl/harness/smoke_hbase-2.6.2_hdfs-3.4.1_zookeeper-3.9.3_listener-class-external-unstable_openshift-false (568.95s)
        --- PASS: kuttl/harness/smoke_hbase-2.6.2_hdfs-3.4.1_zookeeper-3.9.3_listener-class-cluster-internal_openshift-false (346.90s)
        --- FAIL: kuttl/harness/snapshot-export_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (312.53s)
        --- FAIL: kuttl/harness/smoke_hbase-2.6.1_hdfs-3.4.1_zookeeper-3.9.3_listener-class-cluster-internal_openshift-false (557.51s)
        --- PASS: kuttl/harness/profiling_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (309.21s)
        --- PASS: kuttl/harness/profiling_hbase-2.6.1_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (296.23s)
        --- FAIL: kuttl/harness/smoke_hbase-2.6.1_hdfs-3.4.1_zookeeper-3.9.4_listener-class-external-unstable_openshift-false (557.28s)
        --- PASS: kuttl/harness/shutdown_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (521.69s)
        --- FAIL: kuttl/harness/shutdown_hbase-2.6.1_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (516.86s)
        --- PASS: kuttl/harness/omid_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false_omid-1.1.3 (374.47s)
        --- PASS: kuttl/harness/omid_hbase-2.6.1_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false_omid-1.1.3 (314.66s)
        --- PASS: kuttl/harness/smoke_hbase-2.6.1_hdfs-3.4.1_zookeeper-3.9.4_listener-class-cluster-internal_openshift-false (348.65s)
        --- FAIL: kuttl/harness/snapshot-export_hbase-2.6.1_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (312.92s)
        --- PASS: kuttl/harness/kerberos_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_krb5-1.21.1_listener-class-external-unstable_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (685.69s)
        --- PASS: kuttl/harness/kerberos_hbase-2.6.1_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_krb5-1.21.1_listener-class-external-unstable_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (472.72s)
        --- PASS: kuttl/harness/external-access_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (267.54s)
        --- PASS: kuttl/harness/kerberos_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_krb5-1.21.1_listener-class-external-unstable_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_openshift-false (519.06s)
        --- PASS: kuttl/harness/kerberos_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_krb5-1.21.1_listener-class-cluster-internal_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (520.66s)
        --- PASS: kuttl/harness/external-access_hbase-2.6.1_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (254.51s)
        --- PASS: kuttl/harness/logging_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (271.96s)
        --- PASS: kuttl/harness/kerberos_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_krb5-1.21.1_listener-class-cluster-internal_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_openshift-false (565.62s)
        --- PASS: kuttl/harness/cluster-operation_hbase-latest-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (598.16s)
        --- PASS: kuttl/harness/kerberos_hbase-2.6.1_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_krb5-1.21.1_listener-class-cluster-internal_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-false (514.25s)
        --- PASS: kuttl/harness/logging_hbase-2.6.1_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (255.30s)
        --- PASS: kuttl/harness/kerberos_hbase-2.6.1_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_krb5-1.21.1_listener-class-external-unstable_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_openshift-false (510.78s)
        --- PASS: kuttl/harness/kerberos_hbase-2.6.1_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_krb5-1.21.1_listener-class-cluster-internal_kerberos-realm-CLUSTER.LOCAL_kerberos-backend-mit_openshift-false (531.53s)
FAIL

--- PASS: kuttl (531.65s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_hbase-2.6.2_hdfs-3.4.1_zookeeper-3.9.4_listener-class-cluster-internal_openshift-false (531.63s)
PASS
--- PASS: kuttl (563.13s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_hbase-2.6.2_hdfs-3.4.1_zookeeper-3.9.3_listener-class-external-unstable_openshift-false (563.12s)
PASS
--- PASS: kuttl (299.30s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/snapshot-export_hbase-2.6.2_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (299.28s)
PASS
--- PASS: kuttl (411.23s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_hbase-2.6.1_hdfs-3.4.1_zookeeper-3.9.3_listener-class-cluster-internal_openshift-false (411.20s)
PASS
--- PASS: kuttl (539.39s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_hbase-2.6.1_hdfs-3.4.1_zookeeper-3.9.4_listener-class-external-unstable_openshift-false (539.37s)
PASS
--- PASS: kuttl (536.75s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/shutdown_hbase-2.6.1_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (536.73s)
PASS
--- PASS: kuttl (347.03s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/snapshot-export_hbase-2.6.1_hdfs-latest-3.4.1_zookeeper-latest-3.9.4_openshift-false (347.01s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
