### PR TITLE
chore: Bump vector to 0.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@
   Previously, arbitrary file names were silently accepted and ignored ([#751]).
 - Bump `stackable-operator` to 0.111.1 and snafu to 0.9 ([#751], [#752]).
 - Internal operator refactoring: introduce dereference() and validate() steps in the reconciler ([#757]).
+- test: Bump vector-aggregator to 0.55.0, replace /graphql call with gRPC call ([#762]).
 
 [#745]: https://github.com/stackabletech/hbase-operator/pull/745
 [#751]: https://github.com/stackabletech/hbase-operator/pull/751
 [#752]: https://github.com/stackabletech/hbase-operator/pull/752
 [#757]: https://github.com/stackabletech/hbase-operator/pull/757
+[#762]: https://github.com/stackabletech/hbase-operator/pull/762
 
 ## [26.3.0] - 2026-03-16
 

--- a/tests/templates/kuttl/logging/01-install-hbase-vector-aggregator.yaml
+++ b/tests/templates/kuttl/logging/01-install-hbase-vector-aggregator.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install hbase-vector-aggregator vector
       --namespace $NAMESPACE
-      --version 0.49.0
+      --version 0.52.0 `# app version 0.55.0`
       --repo https://helm.vector.dev
       --values hbase-vector-aggregator-values.yaml
 ---

--- a/tests/templates/kuttl/logging/test_log_aggregation.py
+++ b/tests/templates/kuttl/logging/test_log_aggregation.py
@@ -1,45 +1,40 @@
-#!/usr/bin/env python3
-import requests
+import json
+import subprocess
 
 
 def check_sent_events():
-    response = requests.post(
-        "http://hbase-vector-aggregator:8686/graphql",
-        json={
-            "query": """
-                {
-                    transforms(first:100) {
-                        nodes {
-                            componentId
-                            metrics {
-                                sentEventsTotal {
-                                    sentEventsTotal
-                                }
-                            }
-                        }
-                    }
-                }
-            """
-        },
+    response = subprocess.run(
+        [
+            "grpcurl",
+            "-plaintext",
+            "-d",
+            '{"limit": 100}',
+            "hbase-vector-aggregator:8686",
+            "vector.observability.v1.ObservabilityService/GetComponents",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,  # Raise a CalledProcessError if non-zero return
+        timeout=20,  # seconds
     )
+    result = json.loads(response.stdout)
+    components = result.get("components", [])
+    transforms = [
+        c for c in components if c.get("componentType") == "COMPONENT_TYPE_TRANSFORM"
+    ]
 
-    assert response.status_code == 200, (
-        "Cannot access the API of the vector aggregator."
-    )
+    assert len(transforms) > 0, "No transform components found"
 
-    result = response.json()
-
-    transforms = result["data"]["transforms"]["nodes"]
     for transform in transforms:
         sentEvents = transform["metrics"]["sentEventsTotal"]
         componentId = transform["componentId"]
 
         if componentId == "filteredInvalidEvents":
-            assert sentEvents is None or sentEvents["sentEventsTotal"] == 0, (
+            assert sentEvents is None or int(sentEvents) == 0, (
                 "Invalid log events were sent."
             )
         else:
-            assert sentEvents is not None and sentEvents["sentEventsTotal"] > 0, (
+            assert sentEvents is not None and int(sentEvents) > 0, (
                 f'No events were sent in "{componentId}".'
             )
 


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1486

```
--- PASS: kuttl (585.59s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/logging_hbase-2.6.3_hdfs-latest-3.4.2_zookeeper-latest-3.9.4_openshift-false (309.00s)
        --- PASS: kuttl/harness/logging_hbase-2.6.4_hdfs-latest-3.4.2_zookeeper-latest-3.9.4_openshift-false (276.59s)
PASS
```