### PR TITLE
chore: Bump ZooKeeper version to 3.9.5 for SDP 26.7.0

### DIFF
--- a/docs/modules/hbase/examples/getting_started/zk.yaml
+++ b/docs/modules/hbase/examples/getting_started/zk.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.4
+    productVersion: 3.9.5
   servers:
     roleGroups:
       default:

--- a/docs/modules/hbase/examples/getting_started/zk.yaml.j2
+++ b/docs/modules/hbase/examples/getting_started/zk.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.4
+    productVersion: 3.9.5
   servers:
     roleGroups:
       default:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -24,9 +24,10 @@ dimensions:
   - name: zookeeper
     values:
       - 3.9.4
+      - 3.9.5
   - name: zookeeper-latest
     values:
-      - 3.9.4
+      - 3.9.5
   - name: krb5
     values:
       - 1.21.1


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1506.