### PR TITLE
chore: Bump Rust edition to 2024

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -9578,7 +9578,7 @@ rec {
       "stackable-hbase-operator" = rec {
         crateName = "stackable-hbase-operator";
         version = "0.0.0-dev";
-        edition = "2021";
+        edition = "2024";
         crateBin = [
           {
             name = "stackable-hbase-operator";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 version = "0.0.0-dev"
 authors = ["Stackable GmbH <info@stackable.tech>"]
 license = "OSL-3.0"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/stackabletech/hbase-operator"
 
 [workspace.dependencies]

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -399,7 +399,7 @@ impl v1alpha1::HbaseCluster {
             (
                 Vec<PropertyNameKind>,
                 Role<
-                    impl Configuration<Configurable = Self>,
+                    impl Configuration<Configurable = Self> + use<>,
                     v1alpha1::HbaseConfigOverrides,
                     GenericRoleConfig,
                     JavaCommonConfig,

--- a/rust/operator-binary/src/webhooks/conversion.rs
+++ b/rust/operator-binary/src/webhooks/conversion.rs
@@ -37,7 +37,7 @@ pub async fn create_webhook_server(
         field_manager: FIELD_MANAGER.to_owned(),
     };
 
-    let (conversion_webhook, _initial_reconcile_rx) =
+    let (conversion_webhook, _) =
         ConversionWebhook::new(crds_and_handlers, client, conversion_webhook_options);
 
     let webhook_server_options = WebhookServerOptions {


### PR DESCRIPTION
- Fix temporary drop order change in Rust 2024 by explicitly dropping `_initial_reconcile_rx`
- Add `use<>` syntax to `impl Trait` return types (auto-fixed)

Part of https://github.com/stackabletech/issues/issues/832
## Description

*Please add a description here. This will become the commit message of the merge request later.*

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
