### PR TITLE
test(cluster-operations): Use external-unstable ListenerClass

### DIFF
--- a/tests/templates/kuttl/cluster-operation/03-install-hbase.yaml.j2
+++ b/tests/templates/kuttl/cluster-operation/03-install-hbase.yaml.j2
@@ -29,7 +29,7 @@ spec:
       gracefulShutdownTimeout: 1m
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-      listenerClass: external-stable
+      listenerClass: external-unstable
     roleGroups:
       default:
         replicas: 1
@@ -38,7 +38,7 @@ spec:
       gracefulShutdownTimeout: 1m
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-      listenerClass: external-stable
+      listenerClass: external-unstable
     roleGroups:
       default:
         replicas: 1
@@ -47,7 +47,7 @@ spec:
       gracefulShutdownTimeout: 1m
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-      listenerClass: external-stable
+      listenerClass: external-unstable
     roleGroups:
       default:
         replicas: 1

--- a/tests/templates/kuttl/cluster-operation/10-pause-hbase.yaml.j2
+++ b/tests/templates/kuttl/cluster-operation/10-pause-hbase.yaml.j2
@@ -32,7 +32,7 @@ spec:
       gracefulShutdownTimeout: 1m
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-      listenerClass: external-stable
+      listenerClass: external-unstable
     roleGroups:
       default:
         replicas: 1
@@ -41,7 +41,7 @@ spec:
       gracefulShutdownTimeout: 1m
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-      listenerClass: external-stable
+      listenerClass: external-unstable
     roleGroups:
       default:
         replicas: 1
@@ -50,7 +50,7 @@ spec:
       gracefulShutdownTimeout: 1m
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-      listenerClass: external-stable
+      listenerClass: external-unstable
     roleGroups:
       default:
         replicas: 2 # ignored because reconciliation is paused

--- a/tests/templates/kuttl/cluster-operation/20-stop-hbase.yaml.j2
+++ b/tests/templates/kuttl/cluster-operation/20-stop-hbase.yaml.j2
@@ -32,7 +32,7 @@ spec:
       gracefulShutdownTimeout: 1m
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-      listenerClass: external-stable
+      listenerClass: external-unstable
     roleGroups:
       default:
         replicas: 1
@@ -41,7 +41,7 @@ spec:
       gracefulShutdownTimeout: 1m
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-      listenerClass: external-stable
+      listenerClass: external-unstable
     roleGroups:
       default:
         replicas: 1
@@ -50,7 +50,7 @@ spec:
       gracefulShutdownTimeout: 1m
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-      listenerClass: external-stable
+      listenerClass: external-unstable
     roleGroups:
       default:
         replicas: 1 # set to 0 by the operator because cluster is stopped

--- a/tests/templates/kuttl/cluster-operation/30-restart-hbase.yaml.j2
+++ b/tests/templates/kuttl/cluster-operation/30-restart-hbase.yaml.j2
@@ -32,7 +32,7 @@ spec:
       gracefulShutdownTimeout: 1m
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-      listenerClass: external-stable
+      listenerClass: external-unstable
     roleGroups:
       default:
         replicas: 1
@@ -41,7 +41,7 @@ spec:
       gracefulShutdownTimeout: 1m
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-      listenerClass: external-stable
+      listenerClass: external-unstable
     roleGroups:
       default:
         replicas: 1
@@ -50,7 +50,7 @@ spec:
       gracefulShutdownTimeout: 1m
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
-      listenerClass: external-stable
+      listenerClass: external-unstable
     roleGroups:
       default:
         replicas: 1


### PR DESCRIPTION
This test fails in OKD 1.22 due to pending external addresses from the LoadBalancer Controller.
This was previously working. There seem to be some new feature gates in OKD which might explain why LB addresses are never provided.

This does need investigation, but falls outside of the release.

## Testing

```sh
replicated cluster create --name nick-hbase --distribution openshift --instance-type r1.large --version 4.22.0-okd --disk 100 --nodes 3 --ttl 6h
replicated cluster shell --name nick-hbase

./scripts/run-tests --test-suite openshift --test cluster-operation_hbase-latest-2.6.6_hdfs-latest-3.5.0_zookeeper-latest-3.9.5_openshift-true --skip-delete
```

Results

```
--- PASS: kuttl (345.27s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/cluster-operation_hbase-latest-2.6.6_hdfs-latest-3.5.0_zookeeper-latest-3.9.5_openshift-true (344.85s)
PASS
```