### PR TITLE
refactor: Extract apply and update status steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@
 - The RBAC ServiceAccount and RoleBinding are now built with the operator-rs `v2::rbac`
   functions and carry the full set of recommended labels ([#782]).
 - Bump stackable-operator to 0.114.0 ([#786]).
+- The reconciler now applies resources and derives the cluster status in discrete
+  apply and update_status steps ([#787]).
 
 [#776]: https://github.com/stackabletech/hbase-operator/pull/776
 [#782]: https://github.com/stackabletech/hbase-operator/pull/782
 [#786]: https://github.com/stackabletech/hbase-operator/pull/786
+[#787]: https://github.com/stackabletech/hbase-operator/pull/787
 
 ## [26.7.0] - 2026-07-21
 

--- a/rust/operator-binary/src/controller/apply.rs
+++ b/rust/operator-binary/src/controller/apply.rs
@@ -1,0 +1,116 @@
+//! The apply step in the HbaseCluster controller.
+
+use std::marker::PhantomData;
+
+use snafu::{ResultExt, Snafu};
+use stackable_operator::{
+    client::Client,
+    cluster_resources::{ClusterResource, ClusterResourceApplyStrategy, ClusterResources},
+    deep_merger::ObjectOverrides,
+    v2::cluster_resources::cluster_resources_new,
+};
+use strum::{EnumDiscriminants, IntoStaticStr};
+
+use crate::controller::{
+    Applied, KubernetesResources, Prepared, ValidatedCluster, controller_name, operator_name,
+    product_name,
+};
+
+#[derive(Snafu, Debug, EnumDiscriminants)]
+#[strum_discriminants(derive(IntoStaticStr))]
+pub enum Error {
+    #[snafu(display("failed to apply Kubernetes resource"))]
+    ApplyResource {
+        source: stackable_operator::cluster_resources::Error,
+    },
+
+    #[snafu(display("failed to delete orphaned resources"))]
+    DeleteOrphanedResources {
+        source: stackable_operator::cluster_resources::Error,
+    },
+}
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Applier for the Kubernetes resource specifications produced by this controller.
+///
+/// The implementation is not tied to this controller and could theoretically be moved to
+/// stackable_operator if [`KubernetesResources`] would contain all possible resource types.
+pub struct Applier<'a> {
+    client: &'a Client,
+    cluster_resources: ClusterResources<'a>,
+}
+
+impl<'a> Applier<'a> {
+    pub fn new(
+        client: &'a Client,
+        cluster: &ValidatedCluster,
+        apply_strategy: ClusterResourceApplyStrategy,
+        object_overrides: &'a ObjectOverrides,
+    ) -> Applier<'a> {
+        let cluster_resources = cluster_resources_new(
+            &product_name(),
+            &operator_name(),
+            &controller_name(),
+            &cluster.name,
+            &cluster.namespace,
+            &cluster.uid,
+            apply_strategy,
+            object_overrides,
+        );
+
+        Applier {
+            client,
+            cluster_resources,
+        }
+    }
+
+    /// Applies the given Kubernetes resources and marks them as applied.
+    pub async fn apply(
+        mut self,
+        resources: KubernetesResources<Prepared>,
+    ) -> Result<KubernetesResources<Applied>> {
+        // Apply order is: StatefulSets last (a changed mounted ConfigMap/Secret
+        // must exist first, else Pods restart -- commons-operator#111). The ServiceAccount comes
+        // first because the Pods reference it at creation time.
+        let service_accounts = self.add_resources(resources.service_accounts).await?;
+        let role_bindings = self.add_resources(resources.role_bindings).await?;
+        let services = self.add_resources(resources.services).await?;
+        let config_maps = self.add_resources(resources.config_maps).await?;
+        let pod_disruption_budgets = self.add_resources(resources.pod_disruption_budgets).await?;
+        let stateful_sets = self.add_resources(resources.stateful_sets).await?;
+
+        self.cluster_resources
+            .delete_orphaned_resources(self.client)
+            .await
+            .context(DeleteOrphanedResourcesSnafu)?;
+
+        Ok(KubernetesResources {
+            stateful_sets,
+            services,
+            config_maps,
+            pod_disruption_budgets,
+            service_accounts,
+            role_bindings,
+            status: PhantomData,
+        })
+    }
+
+    async fn add_resources<T: ClusterResource + Sync>(
+        &mut self,
+        resources: Vec<T>,
+    ) -> Result<Vec<T>> {
+        let mut applied_resources = vec![];
+
+        for resource in resources {
+            let applied_resource = self
+                .cluster_resources
+                .add(self.client, resource)
+                .await
+                .context(ApplyResourceSnafu)?;
+            applied_resources.push(applied_resource);
+        }
+
+        Ok(applied_resources)
+    }
+}

--- a/rust/operator-binary/src/controller/apply.rs
+++ b/rust/operator-binary/src/controller/apply.rs
@@ -70,15 +70,27 @@ impl<'a> Applier<'a> {
         mut self,
         resources: KubernetesResources<Prepared>,
     ) -> Result<KubernetesResources<Applied>> {
+        // Destructured without `..`, so adding a field to [`KubernetesResources`] fails to
+        // compile here instead of silently never being applied.
+        let KubernetesResources {
+            stateful_sets,
+            services,
+            config_maps,
+            pod_disruption_budgets,
+            service_accounts,
+            role_bindings,
+            status: _,
+        } = resources;
+
         // Apply order is: StatefulSets last (a changed mounted ConfigMap/Secret
         // must exist first, else Pods restart -- commons-operator#111). The ServiceAccount comes
         // first because the Pods reference it at creation time.
-        let service_accounts = self.add_resources(resources.service_accounts).await?;
-        let role_bindings = self.add_resources(resources.role_bindings).await?;
-        let services = self.add_resources(resources.services).await?;
-        let config_maps = self.add_resources(resources.config_maps).await?;
-        let pod_disruption_budgets = self.add_resources(resources.pod_disruption_budgets).await?;
-        let stateful_sets = self.add_resources(resources.stateful_sets).await?;
+        let service_accounts = self.add_resources(service_accounts).await?;
+        let role_bindings = self.add_resources(role_bindings).await?;
+        let services = self.add_resources(services).await?;
+        let config_maps = self.add_resources(config_maps).await?;
+        let pod_disruption_budgets = self.add_resources(pod_disruption_budgets).await?;
+        let stateful_sets = self.add_resources(stateful_sets).await?;
 
         self.cluster_resources
             .delete_orphaned_resources(self.client)

--- a/rust/operator-binary/src/controller/build/mod.rs
+++ b/rust/operator-binary/src/controller/build/mod.rs
@@ -1,7 +1,7 @@
 //! Builders that turn a [`ValidatedCluster`] into
 //! Kubernetes resources.
 
-use std::str::FromStr;
+use std::{marker::PhantomData, str::FromStr};
 
 use snafu::{ResultExt, Snafu};
 use stackable_operator::{
@@ -13,7 +13,7 @@ use stackable_operator::{
 
 use crate::{
     controller::{
-        KubernetesResources, ValidatedCluster,
+        KubernetesResources, Prepared, ValidatedCluster,
         build::resource::{
             config_map::{self, build_rolegroup_config_map},
             discovery::{self, build_discovery_config_map},
@@ -77,7 +77,7 @@ pub enum Error {
 pub fn build(
     cluster: &ValidatedCluster,
     cluster_info: &KubernetesClusterInfo,
-) -> Result<KubernetesResources, Error> {
+) -> Result<KubernetesResources<Prepared>, Error> {
     let mut stateful_sets = vec![];
     let mut services = vec![];
     let mut config_maps = vec![];
@@ -129,6 +129,7 @@ pub fn build(
         pod_disruption_budgets,
         service_accounts: vec![build_service_account(cluster)],
         role_bindings: vec![build_role_binding(cluster)],
+        status: PhantomData,
     })
 }
 

--- a/rust/operator-binary/src/controller/build/mod.rs
+++ b/rust/operator-binary/src/controller/build/mod.rs
@@ -150,6 +150,18 @@ mod tests {
     use super::build;
     use crate::test_utils;
 
+    /// The expected `app.kubernetes.io/version` label value for the given product version.
+    ///
+    /// The `-stackable` suffix carries the operator's own version, which is `0.0.0-dev` on main
+    /// but rewritten by the release process — so tests must derive it rather than hardcode it,
+    /// or they fail on release branches.
+    fn app_version_label(product_version: &str) -> String {
+        format!(
+            "{product_version}-stackable{}",
+            crate::built_info::PKG_VERSION
+        )
+    }
+
     /// Collects the `.metadata.name`s of the given resources, sorted for stable comparison.
     fn sorted_names(resources: &[impl Resource]) -> Vec<&str> {
         let mut names: Vec<&str> = resources
@@ -228,18 +240,18 @@ mod tests {
 
         let expected_labels = BTreeMap::from(
             [
-                ("app.kubernetes.io/component", "none"),
-                ("app.kubernetes.io/instance", "my-hbase"),
+                ("app.kubernetes.io/component", "none".to_string()),
+                ("app.kubernetes.io/instance", "my-hbase".to_string()),
                 (
                     "app.kubernetes.io/managed-by",
-                    "hbase.stackable.com_hbasecluster",
+                    "hbase.stackable.com_hbasecluster".to_string(),
                 ),
-                ("app.kubernetes.io/name", "hbase"),
-                ("app.kubernetes.io/role-group", "none"),
-                ("app.kubernetes.io/version", "2.6.3-stackable0.0.0-dev"),
-                ("stackable.tech/vendor", "Stackable"),
+                ("app.kubernetes.io/name", "hbase".to_string()),
+                ("app.kubernetes.io/role-group", "none".to_string()),
+                ("app.kubernetes.io/version", app_version_label("2.6.3")),
+                ("stackable.tech/vendor", "Stackable".to_string()),
             ]
-            .map(|(key, value)| (key.to_string(), value.to_string())),
+            .map(|(key, value)| (key.to_string(), value)),
         );
         let service_account = resources
             .service_accounts

--- a/rust/operator-binary/src/controller/build/mod.rs
+++ b/rust/operator-binary/src/controller/build/mod.rs
@@ -5,7 +5,10 @@ use std::str::FromStr;
 
 use snafu::{ResultExt, Snafu};
 use stackable_operator::{
-    utils::cluster_info::KubernetesClusterInfo, v2::types::operator::RoleGroupName,
+    builder::meta::ObjectMetaBuilder,
+    kvp::Labels,
+    utils::cluster_info::KubernetesClusterInfo,
+    v2::{builder::meta::ownerreference_from_resource, types::operator::RoleGroupName},
 };
 
 use crate::{
@@ -26,6 +29,25 @@ use crate::{
 // Placeholder role-group name used for the recommended labels of the role-level discovery
 // `ConfigMap` (which is not tied to a single role group).
 stackable_operator::constant!(pub(crate) PLACEHOLDER_DISCOVERY_ROLE_GROUP: RoleGroupName = "discovery");
+
+/// Returns an [`ObjectMetaBuilder`] pre-filled with the cluster's namespace, an owner
+/// reference back to the cluster, the resource `name` and the given `recommended_labels`.
+///
+/// Consolidates the metadata chain repeated by the child-resource builders. Call sites that
+/// need extra labels/annotations chain them onto the returned builder.
+pub(crate) fn object_meta(
+    cluster: &ValidatedCluster,
+    name: impl Into<String>,
+    recommended_labels: Labels,
+) -> ObjectMetaBuilder {
+    let mut builder = ObjectMetaBuilder::new();
+    builder
+        .name_and_namespace(cluster)
+        .name(name)
+        .ownerreference(ownerreference_from_resource(cluster, None, Some(true)))
+        .with_labels(recommended_labels);
+    builder
+}
 
 #[derive(Snafu, Debug)]
 pub enum Error {

--- a/rust/operator-binary/src/controller/build/resource/config_map.rs
+++ b/rust/operator-binary/src/controller/build/resource/config_map.rs
@@ -14,7 +14,7 @@ use crate::{
         ValidatedCluster,
         build::{
             jvm::construct_role_specific_non_heap_jvm_args,
-            kerberos,
+            kerberos, object_meta,
             properties::{
                 ConfigFileName, hbase_env, hbase_site, product_logging, security_properties,
                 ssl_client, ssl_server,
@@ -108,16 +108,15 @@ pub fn build_rolegroup_config_map(
             },
         )?;
 
-    let cm_metadata = cluster
-        .object_meta(
-            cluster
-                .role_group_resource_names(role, role_group_name)
-                .role_group_config_map()
-                .to_string(),
-            role,
-            role_group_name,
-        )
-        .build();
+    let cm_metadata = object_meta(
+        cluster,
+        cluster
+            .role_group_resource_names(role, role_group_name)
+            .role_group_config_map()
+            .to_string(),
+        cluster.recommended_labels(role, role_group_name),
+    )
+    .build();
 
     let mut builder = ConfigMapBuilder::new();
     builder

--- a/rust/operator-binary/src/controller/build/resource/discovery.rs
+++ b/rust/operator-binary/src/controller/build/resource/discovery.rs
@@ -9,7 +9,9 @@ use stackable_operator::{
 use crate::{
     controller::{
         ValidatedCluster,
-        build::{PLACEHOLDER_DISCOVERY_ROLE_GROUP, kerberos, properties::ConfigFileName},
+        build::{
+            PLACEHOLDER_DISCOVERY_ROLE_GROUP, kerberos, object_meta, properties::ConfigFileName,
+        },
     },
     crd::HbaseRole,
 };
@@ -41,13 +43,15 @@ pub fn build_discovery_config_map(
             // The discovery `ConfigMap` is a cluster-wide object (not tied to a single role
             // group), so it is named after the cluster and labelled with the region-server role
             // and a `discovery` placeholder role-group.
-            cluster
-                .object_meta(
-                    cluster.name.to_string(),
+            object_meta(
+                cluster,
+                cluster.name.to_string(),
+                cluster.recommended_labels(
                     &HbaseRole::RegionServer,
                     &PLACEHOLDER_DISCOVERY_ROLE_GROUP,
-                )
-                .build(),
+                ),
+            )
+            .build(),
         )
         .add_data(
             ConfigFileName::HbaseSite.to_string(),

--- a/rust/operator-binary/src/controller/build/resource/service.rs
+++ b/rust/operator-binary/src/controller/build/resource/service.rs
@@ -6,7 +6,7 @@ use stackable_operator::{
 };
 
 use crate::{
-    controller::{RoleGroupName, ValidatedCluster},
+    controller::{RoleGroupName, ValidatedCluster, build::object_meta},
     crd::HbaseRole,
 };
 
@@ -32,16 +32,15 @@ pub fn build_rolegroup_service(
         .collect();
 
     Service {
-        metadata: cluster
-            .object_meta(
-                cluster
-                    .role_group_resource_names(hbase_role, role_group_name)
-                    .headless_service_name()
-                    .to_string(),
-                hbase_role,
-                role_group_name,
-            )
-            .build(),
+        metadata: object_meta(
+            cluster,
+            cluster
+                .role_group_resource_names(hbase_role, role_group_name)
+                .headless_service_name()
+                .to_string(),
+            cluster.recommended_labels(hbase_role, role_group_name),
+        )
+        .build(),
         spec: Some(ServiceSpec {
             // Internal communication does not need to be exposed
             type_: Some("ClusterIP".to_string()),
@@ -74,27 +73,26 @@ pub fn build_rolegroup_metrics_service(
     }];
 
     Service {
-        metadata: cluster
-            .object_meta(
-                cluster
-                    .role_group_resource_names(hbase_role, role_group_name)
-                    .metrics_service_name()
-                    .to_string(),
-                hbase_role,
-                role_group_name,
-            )
-            .with_labels(prometheus_labels(&Scraping::Enabled))
-            .with_annotations(prometheus_annotations(
-                &Scraping::Enabled,
-                if cluster.has_https_enabled() {
-                    &Scheme::Https
-                } else {
-                    &Scheme::Http
-                },
-                "/prometheus",
-                &hbase_role.metrics_port(),
-            ))
-            .build(),
+        metadata: object_meta(
+            cluster,
+            cluster
+                .role_group_resource_names(hbase_role, role_group_name)
+                .metrics_service_name()
+                .to_string(),
+            cluster.recommended_labels(hbase_role, role_group_name),
+        )
+        .with_labels(prometheus_labels(&Scraping::Enabled))
+        .with_annotations(prometheus_annotations(
+            &Scraping::Enabled,
+            if cluster.has_https_enabled() {
+                &Scheme::Https
+            } else {
+                &Scheme::Http
+            },
+            "/prometheus",
+            &hbase_role.metrics_port(),
+        ))
+        .build(),
         spec: Some(ServiceSpec {
             // Internal communication does not need to be exposed
             type_: Some("ClusterIP".to_owned()),

--- a/rust/operator-binary/src/controller/build/resource/statefulset.rs
+++ b/rust/operator-binary/src/controller/build/resource/statefulset.rs
@@ -38,6 +38,7 @@ use crate::{
         build::{
             graceful_shutdown::{self, add_graceful_shutdown_config},
             kerberos::{self, add_kerberos_pod_config},
+            object_meta,
             properties::product_logging::MAX_HBASE_LOG_FILES_SIZE,
         },
     },
@@ -310,14 +311,13 @@ pub fn build_rolegroup_statefulset(
 
     pod_template.merge_from(validated_rg_config.pod_overrides.clone());
 
-    let metadata = cluster
-        .object_meta(
-            resource_names.stateful_set_name().to_string(),
-            hbase_role,
-            role_group_name,
-        )
-        .with_label(RESTART_CONTROLLER_ENABLED_LABEL.to_owned())
-        .build();
+    let metadata = object_meta(
+        cluster,
+        resource_names.stateful_set_name().to_string(),
+        cluster.recommended_labels(hbase_role, role_group_name),
+    )
+    .with_label(RESTART_CONTROLLER_ENABLED_LABEL.to_owned())
+    .build();
 
     let statefulset_match_labels = cluster.role_group_selector(hbase_role, role_group_name);
 

--- a/rust/operator-binary/src/controller/mod.rs
+++ b/rust/operator-binary/src/controller/mod.rs
@@ -1,9 +1,11 @@
+pub mod apply;
 pub mod build;
 pub mod dereference;
+pub mod update_status;
 pub mod validate;
 pub mod zookeeper;
 
-use std::{collections::BTreeMap, str::FromStr};
+use std::{collections::BTreeMap, marker::PhantomData, str::FromStr};
 
 use const_format::concatcp;
 pub use stackable_operator::v2::types::operator::RoleGroupName;
@@ -58,17 +60,28 @@ pub(crate) fn controller_name() -> ControllerName {
         .expect("the controller name is a valid label value")
 }
 
+/// Marker for prepared Kubernetes resources which are not applied yet.
+pub struct Prepared;
+
+/// Marker for applied Kubernetes resources.
+pub struct Applied;
+
 /// The complete set of Kubernetes resources built for a [`ValidatedCluster`], ready to be applied.
 ///
 /// hbase exposes its listeners as volume/PVC sources inside the `StatefulSet` rather than as
 /// top-level `Listener` objects, so (unlike some sibling operators) there is no `listeners` field.
-pub struct KubernetesResources {
+///
+/// `T` is a marker that indicates if these resources are only [`Prepared`] or already [`Applied`].
+/// The marker is useful e.g. to ensure that the cluster status is updated based on the applied
+/// resources.
+pub struct KubernetesResources<T> {
     pub stateful_sets: Vec<StatefulSet>,
     pub services: Vec<Service>,
     pub config_maps: Vec<ConfigMap>,
     pub pod_disruption_budgets: Vec<PodDisruptionBudget>,
     pub service_accounts: Vec<ServiceAccount>,
     pub role_bindings: Vec<RoleBinding>,
+    pub status: PhantomData<T>,
 }
 
 /// The validated cluster: proves that config merging and validation succeeded for

--- a/rust/operator-binary/src/controller/mod.rs
+++ b/rust/operator-binary/src/controller/mod.rs
@@ -8,7 +8,6 @@ use std::{collections::BTreeMap, str::FromStr};
 use const_format::concatcp;
 pub use stackable_operator::v2::types::operator::RoleGroupName;
 use stackable_operator::{
-    builder::meta::ObjectMetaBuilder,
     commons::product_image_selection::ResolvedProductImage,
     k8s_openapi::{
         api::{
@@ -23,7 +22,6 @@ use stackable_operator::{
     kvp::Labels,
     v2::{
         HasName, HasUid, NameIsValidLabelValue,
-        builder::meta::ownerreference_from_resource,
         kvp::label::{recommended_labels, role_group_selector},
         role_group_utils::ResourceNames,
         role_utils,
@@ -191,26 +189,6 @@ impl ValidatedCluster {
         role_group_name: &RoleGroupName,
     ) -> Labels {
         role_group_selector(self, &product_name(), &hbase_role.into(), role_group_name)
-    }
-
-    /// Returns an [`ObjectMetaBuilder`] pre-filled with the namespace, an owner reference back to
-    /// this cluster, and the recommended labels for a resource named `name` in `role_group_name`.
-    ///
-    /// Consolidates the metadata chain repeated by the child-resource builders. Call sites that
-    /// need extra labels/annotations chain them onto the returned builder.
-    pub(crate) fn object_meta(
-        &self,
-        name: impl Into<String>,
-        hbase_role: &HbaseRole,
-        role_group_name: &RoleGroupName,
-    ) -> ObjectMetaBuilder {
-        let mut builder = ObjectMetaBuilder::new();
-        builder
-            .name_and_namespace(self)
-            .name(name)
-            .ownerreference(ownerreference_from_resource(self, None, Some(true)))
-            .with_labels(self.recommended_labels(hbase_role, role_group_name));
-        builder
     }
 
     /// Whether Kerberos is enabled for this cluster.

--- a/rust/operator-binary/src/controller/update_status.rs
+++ b/rust/operator-binary/src/controller/update_status.rs
@@ -1,0 +1,55 @@
+//! The update_status step in the HbaseCluster controller.
+
+use snafu::{ResultExt, Snafu};
+use stackable_operator::{
+    client::Client,
+    status::condition::{
+        compute_conditions, operations::ClusterOperationsConditionBuilder,
+        statefulset::StatefulSetConditionBuilder,
+    },
+};
+use strum::{EnumDiscriminants, IntoStaticStr};
+
+use crate::{
+    controller::{Applied, KubernetesResources},
+    crd::{HbaseClusterStatus, OPERATOR_NAME, v1alpha1},
+};
+
+#[derive(Snafu, Debug, EnumDiscriminants)]
+#[strum_discriminants(derive(IntoStaticStr))]
+pub enum Error {
+    #[snafu(display("failed to update status"))]
+    ApplyStatus {
+        source: stackable_operator::client::Error,
+    },
+}
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Computes the cluster status from the applied resources and patches it onto the
+/// [`v1alpha1::HbaseCluster`]. Takes [`KubernetesResources<Applied>`] so the type system
+/// proves the status derives from applied resources, not merely built ones.
+pub async fn update_status(
+    client: &Client,
+    hbase: &v1alpha1::HbaseCluster,
+    applied: &KubernetesResources<Applied>,
+) -> Result<()> {
+    let mut ss_cond_builder = StatefulSetConditionBuilder::default();
+    for stateful_set in &applied.stateful_sets {
+        ss_cond_builder.add(stateful_set.clone());
+    }
+
+    let cluster_operation_cond_builder =
+        ClusterOperationsConditionBuilder::new(&hbase.spec.cluster_operation);
+
+    let status = HbaseClusterStatus {
+        conditions: compute_conditions(hbase, &[&ss_cond_builder, &cluster_operation_cond_builder]),
+    };
+
+    client
+        .apply_patch_status(OPERATOR_NAME, hbase, &status)
+        .await
+        .context(ApplyStatusSnafu)?;
+
+    Ok(())
+}

--- a/rust/operator-binary/src/hbase_controller.rs
+++ b/rust/operator-binary/src/hbase_controller.rs
@@ -1,7 +1,7 @@
 //! Ensures that `Pod`s are configured and running for each [`v1alpha1::HbaseCluster`].
 //!
-//! This is the controller driver: it runs the `dereference -> validate -> build -> apply`
-//! pipeline. The validated cluster type and the resource builders live under the
+//! This is the controller driver: it runs the
+//! `dereference -> validate -> build -> apply -> update_status` pipeline. The validated cluster type and the resource builders live under the
 //! [`crate::controller`] module tree; this file is kept next to `main.rs` for consistency with
 //! the other Stackable operators.
 
@@ -17,17 +17,16 @@ use stackable_operator::{
     },
     logging::controller::ReconcilerError,
     shared::time::Duration,
-    status::condition::{
-        compute_conditions, operations::ClusterOperationsConditionBuilder,
-        statefulset::StatefulSetConditionBuilder,
-    },
-    v2::cluster_resources::cluster_resources_new,
 };
 use strum::{EnumDiscriminants, IntoStaticStr};
 
 use crate::{
-    controller::{build, controller_name, operator_name, product_name},
-    crd::{HbaseClusterStatus, OPERATOR_NAME, v1alpha1},
+    controller::{
+        apply::{self, Applier},
+        build,
+        update_status::{self, update_status},
+    },
+    crd::v1alpha1,
 };
 
 pub struct Ctx {
@@ -38,23 +37,11 @@ pub struct Ctx {
 #[derive(Snafu, Debug, EnumDiscriminants)]
 #[strum_discriminants(derive(IntoStaticStr))]
 pub enum Error {
-    #[snafu(display("failed to delete orphaned resources"))]
-    DeleteOrphanedResources {
-        source: stackable_operator::cluster_resources::Error,
-    },
+    #[snafu(display("failed to apply the Kubernetes resources"))]
+    ApplyResources { source: apply::Error },
 
     #[snafu(display("failed to build cluster resources"))]
     BuildResources { source: build::Error },
-
-    #[snafu(display("failed to apply cluster resource"))]
-    ApplyResource {
-        source: stackable_operator::cluster_resources::Error,
-    },
-
-    #[snafu(display("failed to update status"))]
-    ApplyStatus {
-        source: stackable_operator::client::Error,
-    },
 
     #[snafu(display("HBaseCluster object is invalid"))]
     InvalidHBaseCluster {
@@ -70,6 +57,9 @@ pub enum Error {
     Validate {
         source: crate::controller::validate::Error,
     },
+
+    #[snafu(display("failed to update the cluster status"))]
+    UpdateStatus { source: update_status::Error },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -105,79 +95,22 @@ pub async fn reconcile_hbase(
     )
     .context(ValidateSnafu)?;
 
-    let mut cluster_resources = cluster_resources_new(
-        &product_name(),
-        &operator_name(),
-        &controller_name(),
-        &validated_cluster.name,
-        &validated_cluster.namespace,
-        &validated_cluster.uid,
-        ClusterResourceApplyStrategy::from(&hbase.spec.cluster_operation),
-        &hbase.spec.object_overrides,
-    );
-
     let resources = build::build(&validated_cluster, &client.kubernetes_cluster_info)
         .context(BuildResourcesSnafu)?;
 
-    let mut ss_cond_builder = StatefulSetConditionBuilder::default();
+    let applied = Applier::new(
+        client,
+        &validated_cluster,
+        ClusterResourceApplyStrategy::from(&hbase.spec.cluster_operation),
+        &hbase.spec.object_overrides,
+    )
+    .apply(resources)
+    .await
+    .context(ApplyResourcesSnafu)?;
 
-    // Apply order: everything before the StatefulSets, StatefulSets last. A changed ConfigMap or
-    // Secret a Pod mounts must exist before the Pod restarts, otherwise the Pod restarts again
-    // unnecessarily. See https://github.com/stackabletech/commons-operator/issues/111 for details.
-    for service_account in resources.service_accounts {
-        cluster_resources
-            .add(client, service_account)
-            .await
-            .context(ApplyResourceSnafu)?;
-    }
-    for role_binding in resources.role_bindings {
-        cluster_resources
-            .add(client, role_binding)
-            .await
-            .context(ApplyResourceSnafu)?;
-    }
-    for service in resources.services {
-        cluster_resources
-            .add(client, service)
-            .await
-            .context(ApplyResourceSnafu)?;
-    }
-    for config_map in resources.config_maps {
-        cluster_resources
-            .add(client, config_map)
-            .await
-            .context(ApplyResourceSnafu)?;
-    }
-    for pdb in resources.pod_disruption_budgets {
-        cluster_resources
-            .add(client, pdb)
-            .await
-            .context(ApplyResourceSnafu)?;
-    }
-    for statefulset in resources.stateful_sets {
-        ss_cond_builder.add(
-            cluster_resources
-                .add(client, statefulset)
-                .await
-                .context(ApplyResourceSnafu)?,
-        );
-    }
-
-    let cluster_operation_cond_builder =
-        ClusterOperationsConditionBuilder::new(&hbase.spec.cluster_operation);
-
-    let status = HbaseClusterStatus {
-        conditions: compute_conditions(hbase, &[&ss_cond_builder, &cluster_operation_cond_builder]),
-    };
-
-    cluster_resources
-        .delete_orphaned_resources(client)
+    update_status(client, hbase, &applied)
         .await
-        .context(DeleteOrphanedResourcesSnafu)?;
-    client
-        .apply_patch_status(OPERATOR_NAME, hbase, &status)
-        .await
-        .context(ApplyStatusSnafu)?;
+        .context(UpdateStatusSnafu)?;
 
     Ok(Action::await_change())
 }
@@ -188,7 +121,7 @@ pub fn error_policy(
     _ctx: Arc<Ctx>,
 ) -> Action {
     match error {
-        // root object is invalid, will be requed when modified
+        // root object is invalid, will be requeued when modified
         Error::InvalidHBaseCluster { .. } => Action::await_change(),
         _ => Action::requeue(*Duration::from_secs(5)),
     }


### PR DESCRIPTION
## Description

This PR covers the following:

- extracts apply and update_status steps
- moves secret creation to the apply step
- moves object_meta out of the validated cluster code (missed on the last iteration of PRs)
- ensure correct label versions are used in the tests (ditto)

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [x] Code contains useful comments
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
